### PR TITLE
Refactor notification queries

### DIFF
--- a/server/db/notifications.ts
+++ b/server/db/notifications.ts
@@ -1,0 +1,67 @@
+import { db } from './index';
+import * as schema from '@shared/schema';
+import { eq, desc, and } from 'drizzle-orm';
+import { Notification, InsertNotification } from '@shared/schema';
+
+export async function getNotifications(): Promise<Notification[]> {
+  return db.select().from(schema.notifications);
+}
+
+export async function getNotification(id: number): Promise<Notification | undefined> {
+  const notifications = await db.select()
+    .from(schema.notifications)
+    .where(eq(schema.notifications.id, id))
+    .limit(1);
+  return notifications[0];
+}
+
+export async function getNotificationsByUser(userId: number): Promise<Notification[]> {
+  return db.select()
+    .from(schema.notifications)
+    .where(eq(schema.notifications.userId, userId))
+    .orderBy(desc(schema.notifications.createdAt));
+}
+
+export async function getUnreadNotificationsByUser(userId: number): Promise<Notification[]> {
+  return db.select()
+    .from(schema.notifications)
+    .where(
+      and(
+        eq(schema.notifications.userId, userId),
+        eq(schema.notifications.isRead, false)
+      )
+    )
+    .orderBy(desc(schema.notifications.createdAt));
+}
+
+export async function createNotification(notificationData: InsertNotification): Promise<Notification> {
+  const [notification] = await db.insert(schema.notifications)
+    .values({ ...notificationData, isRead: false })
+    .returning();
+  return notification;
+}
+
+export async function markNotificationAsRead(id: number): Promise<Notification | undefined> {
+  const [notification] = await db.update(schema.notifications)
+    .set({ isRead: true })
+    .where(eq(schema.notifications.id, id))
+    .returning();
+  return notification;
+}
+
+export async function deleteNotification(id: number): Promise<boolean> {
+  const result = await db.delete(schema.notifications)
+    .where(eq(schema.notifications.id, id));
+  return (result.rowCount || 0) > 0;
+}
+
+export async function markAllNotificationsAsRead(userId: number): Promise<void> {
+  await db.update(schema.notifications)
+    .set({ isRead: true })
+    .where(
+      and(
+        eq(schema.notifications.userId, userId),
+        eq(schema.notifications.isRead, false)
+      )
+    );
+}


### PR DESCRIPTION
## Summary
- extract notification queries into a dedicated module
- simplify `PostgresStorage` by delegating notification methods to that module
- remove duplicated debug implementations

## Testing
- `npm run check` *(fails: type errors)*

------
https://chatgpt.com/codex/tasks/task_e_6849800d55e0832082a4cc2653f91e43