### PR TITLE
Fix schedule items mapping type

### DIFF
--- a/server/db/storage.ts
+++ b/server/db/storage.ts
@@ -299,7 +299,7 @@ export class SupabaseStorage {
     
     return results.map(({ schedule_items, subjects }) => ({
       ...schedule_items,
-      subject: subjects
+      subject: subjects!
     }));
   }
 


### PR DESCRIPTION
## Summary
- assert non-null `subject` in `getScheduleItemsByTeacher`

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68499a42218483209fa3d6a492579441