### PR TITLE
Fix type mismatch in getStudentsBySubject

### DIFF
--- a/server/db/storage.ts
+++ b/server/db/storage.ts
@@ -196,7 +196,7 @@ export class SupabaseStorage {
   }
 
   async getStudentsBySubject(subjectId: number): Promise<User[]> {
-    return db.select()
+    const results = await db.select({ users: schema.users })
       .from(schema.users)
       .innerJoin(
         schema.enrollments,
@@ -207,6 +207,8 @@ export class SupabaseStorage {
       )
       .where(eq(schema.users.role, 'student'))
       .orderBy(schema.users.lastName, schema.users.firstName);
+
+    return results.map((r) => r.users);
   }
 
   async getSubjectsByStudent(studentId: number): Promise<Subject[]> {


### PR DESCRIPTION
## Summary
- ensure `getStudentsBySubject` selects only user columns and maps to `User[]`

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_6849b4aab8588320b0b651c0f4b0e924