### PR TITLE
Add Supabase configuration docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Supabase / PostgreSQL connection string
+SUPABASE_DATABASE_URL=postgresql://USER:PASSWORD@HOST:5432/DATABASE
+
+# Optional: same URL used by Drizzle
+DATABASE_URL=
+
+# Secret used to sign session cookies
+SESSION_SECRET=change-me

--- a/README.md
+++ b/README.md
@@ -1,0 +1,52 @@
+# CampusConnect Setup
+
+This project can store all data in a single Supabase (PostgreSQL) database.
+Follow the steps below to configure the connection.
+
+## 1. Create a Supabase project
+
+From the Supabase dashboard create a new project and obtain the **connection string**
+for the Postgres database. It should look similar to:
+
+```
+postgresql://USER:PASSWORD@HOST:PORT/DATABASE
+```
+
+## 2. Configure environment variables
+
+Create a `.env` file in the project root (you can copy `.env.example`).
+Provide the connection string and a session secret:
+
+```
+SUPABASE_DATABASE_URL=postgresql://USER:PASSWORD@HOST:PORT/DATABASE
+SESSION_SECRET=your-session-secret
+```
+
+The `DATABASE_URL` variable is also used by the migration tool. You can set it to
+same value or leave it unset if you only use `SUPABASE_DATABASE_URL`.
+
+## 3. Apply the database schema
+
+Run the following command once to create all tables in Supabase:
+
+```
+npm run db:push
+```
+
+This command uses **Drizzle** to push the schema defined in `shared/schema.ts` to
+Supabase. If you plan to store sessions in the database, also execute the SQL
+script:
+
+```
+psql "$SUPABASE_DATABASE_URL" -f server/db/session-table.sql
+```
+
+## 4. Start the development server
+
+After the variables are set and the schema is applied you can start the app:
+
+```
+npm run dev
+```
+
+The server will automatically use `SupabaseStorage` for all data access.

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,7 +1,9 @@
 import { defineConfig } from "drizzle-kit";
 
-if (!process.env.DATABASE_URL) {
-  throw new Error("DATABASE_URL, ensure the database is provisioned");
+const connectionString = process.env.SUPABASE_DATABASE_URL || process.env.DATABASE_URL;
+
+if (!connectionString) {
+  throw new Error("DATABASE_URL or SUPABASE_DATABASE_URL must be set");
 }
 
 export default defineConfig({
@@ -9,6 +11,6 @@ export default defineConfig({
   schema: "./shared/schema.ts",
   dialect: "postgresql",
   dbCredentials: {
-    url: process.env.DATABASE_URL,
+    url: connectionString,
   },
 });

--- a/server/db.ts
+++ b/server/db.ts
@@ -2,12 +2,14 @@ import 'dotenv/config';
 import { Pool } from 'pg';
 import { drizzle } from 'drizzle-orm/node-postgres';
 import * as schema from "@shared/schema";
-console.log('DATABASE_URL:', process.env.DATABASE_URL);
-if (!process.env.DATABASE_URL) {
+
+const connectionString = process.env.SUPABASE_DATABASE_URL || process.env.DATABASE_URL;
+
+if (!connectionString) {
   throw new Error(
-    "DATABASE_URL must be set. Did you forget to provision a database?",
+    'SUPABASE_DATABASE_URL or DATABASE_URL must be set. Did you forget to provision a database?',
   );
 }
 
-export const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+export const pool = new Pool({ connectionString });
 export const db = drizzle(pool, { schema });

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -6,7 +6,7 @@ import * as schema from '@shared/schema';
 // Create a connection pool to Supabase (PostgreSQL)
 const connectionString = process.env.SUPABASE_DATABASE_URL || process.env.DATABASE_URL;
 if (!connectionString) {
-  throw new Error('SUPABASE_DATABASE_URL must be provided');
+  throw new Error('SUPABASE_DATABASE_URL or DATABASE_URL must be provided');
 }
 
 const pool = new Pool({


### PR DESCRIPTION
## Summary
- document how to set up Supabase
- add example env file with required variables
- support SUPABASE_DATABASE_URL in database config

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68499d300dc883208b85a77799ddaeb7