### PR TITLE
Refactor assignments module

### DIFF
--- a/client/src/pages/assignments/CreateAssignmentDialog.tsx
+++ b/client/src/pages/assignments/CreateAssignmentDialog.tsx
@@ -1,0 +1,116 @@
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { createAssignmentSchema } from './useAssignments';
+import * as z from 'zod';
+
+interface Props {
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+  subjects: any[] | undefined;
+  createAssignment: (data: z.infer<typeof createAssignmentSchema>) => void;
+  loading: boolean;
+}
+
+export default function CreateAssignmentDialog({ open, onOpenChange, subjects, createAssignment, loading }: Props) {
+  const form = useForm<z.infer<typeof createAssignmentSchema>>({
+    resolver: zodResolver(createAssignmentSchema),
+    defaultValues: { title: '', description: '', subjectId: '', dueDate: '' },
+  });
+
+  const onSubmit = (data: z.infer<typeof createAssignmentSchema>) => {
+    createAssignment(data);
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[550px]">
+        <DialogHeader>
+          <DialogTitle>Create New Assignment</DialogTitle>
+          <DialogDescription>Add a new assignment for your students.</DialogDescription>
+        </DialogHeader>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="title"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Title</FormLabel>
+                  <FormControl>
+                    <Input placeholder="Assignment title" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="description"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Description</FormLabel>
+                  <FormControl>
+                    <Textarea placeholder="Describe the assignment" className="min-h-[100px]" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="subjectId"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Subject</FormLabel>
+                  <Select onValueChange={field.onChange} defaultValue={field.value}>
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Select a subject" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {subjects?.map((subject: any) => (
+                        <SelectItem key={subject.id} value={subject.id.toString()}>
+                          {subject.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="dueDate"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Due Date</FormLabel>
+                  <FormControl>
+                    <Input type="date" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <DialogFooter>
+              <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+                Cancel
+              </Button>
+              <Button type="submit" disabled={loading}>
+                {loading ? 'Creating...' : 'Create Assignment'}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/pages/assignments/SubmitAssignmentDialog.tsx
+++ b/client/src/pages/assignments/SubmitAssignmentDialog.tsx
@@ -1,0 +1,66 @@
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
+import { Textarea } from '@/components/ui/textarea';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { submitAssignmentSchema } from './useAssignments';
+import * as z from 'zod';
+
+interface Props {
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+  selected: any | null;
+  submitAssignment: (data: z.infer<typeof submitAssignmentSchema> & { assignmentId: number }) => void;
+  loading: boolean;
+}
+
+export default function SubmitAssignmentDialog({ open, onOpenChange, selected, submitAssignment, loading }: Props) {
+  const form = useForm<z.infer<typeof submitAssignmentSchema>>({
+    resolver: zodResolver(submitAssignmentSchema),
+    defaultValues: { content: '', status: 'completed' },
+  });
+
+  const onSubmit = (data: z.infer<typeof submitAssignmentSchema>) => {
+    if (!selected) return;
+    submitAssignment({ ...data, assignmentId: selected.id });
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[550px]">
+        <DialogHeader>
+          <DialogTitle>Submit Assignment</DialogTitle>
+          <DialogDescription>{selected?.title}</DialogDescription>
+        </DialogHeader>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="content"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Submission</FormLabel>
+                  <FormControl>
+                    <Textarea placeholder="Enter your assignment submission" className="min-h-[150px]" {...field} />
+                  </FormControl>
+                  <FormDescription>You can also attach files or links to your work.</FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <DialogFooter>
+              <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+                Cancel
+              </Button>
+              <Button type="submit" disabled={loading}>
+                {loading ? 'Submitting...' : 'Submit Assignment'}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/pages/assignments/useAssignments.ts
+++ b/client/src/pages/assignments/useAssignments.ts
@@ -1,0 +1,105 @@
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useAuth } from '@/hooks/use-auth';
+import { useToast } from '@/hooks/use-toast';
+import { queryClient as globalClient } from '@/lib/queryClient';
+import * as z from 'zod';
+
+export const createAssignmentSchema = z.object({
+  title: z.string().min(5, 'Title must be at least 5 characters'),
+  description: z.string().min(10, 'Description must be at least 10 characters'),
+  subjectId: z.string().min(1, 'Subject is required'),
+  dueDate: z.string().min(1, 'Due date is required'),
+});
+
+export const submitAssignmentSchema = z.object({
+  content: z.string().min(10, 'Submission content must be at least 10 characters'),
+  status: z.enum(['completed']),
+});
+
+export function useAssignments() {
+  const { user } = useAuth();
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+  const isStudent = user?.role === 'student';
+  const isTeacher = user?.role === 'teacher';
+  const [selectedAssignment, setSelectedAssignment] = useState<any>(null);
+
+  const { data: assignments, isLoading, error } = useQuery({
+    queryKey: [isStudent ? '/api/assignments/student' : '/api/assignments/teacher'],
+    queryFn: async () => {
+      const endpoint = isStudent ? '/api/assignments/student' : '/api/assignments/teacher';
+      const response = await fetch(endpoint);
+      if (!response.ok) throw new Error('Failed to fetch assignments');
+      return await response.json();
+    },
+    enabled: !!user,
+  });
+
+  const { data: subjects } = useQuery({
+    queryKey: ['/api/subjects/teacher'],
+    queryFn: async () => {
+      const response = await fetch('/api/subjects/teacher');
+      if (!response.ok) throw new Error('Failed to fetch subjects');
+      return await response.json();
+    },
+    enabled: !!isTeacher,
+  });
+
+  const createAssignmentMutation = useMutation({
+    mutationFn: async (data: z.infer<typeof createAssignmentSchema>) => {
+      const response = await fetch('/api/assignments', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ...data, teacherId: user!.id }),
+      });
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.message || 'Failed to create assignment');
+      }
+      return await response.json();
+    },
+    onSuccess: () => {
+      toast({ title: 'Assignment Created' });
+      queryClient.invalidateQueries({ queryKey: ['/api/assignments/teacher'] });
+    },
+    onError: (error: Error) => {
+      toast({ title: 'Error', description: error.message, variant: 'destructive' });
+    },
+  });
+
+  const submitAssignmentMutation = useMutation({
+    mutationFn: async (data: z.infer<typeof submitAssignmentSchema> & { assignmentId: number }) => {
+      const response = await fetch('/api/submissions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ...data, studentId: user!.id }),
+      });
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.message || 'Failed to submit assignment');
+      }
+      return await response.json();
+    },
+    onSuccess: () => {
+      toast({ title: 'Assignment Submitted', description: 'Your assignment has been submitted successfully.' });
+      globalClient.invalidateQueries({ queryKey: ['/api/assignments/student'] });
+    },
+    onError: (error: Error) => {
+      toast({ title: 'Error', description: error.message, variant: 'destructive' });
+    },
+  });
+
+  return {
+    assignments,
+    subjects,
+    isLoading,
+    error,
+    selectedAssignment,
+    setSelectedAssignment,
+    createAssignmentMutation,
+    submitAssignmentMutation,
+    isStudent,
+    isTeacher,
+  };
+}


### PR DESCRIPTION
## Summary
- refactor Assignments page and split dialogs into components
- add custom `useAssignments` hook
- update page to use new hook and components

## Testing
- `npm run dev` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_684a744ddff48320b3bfc5d1b67884b7