### PR TITLE
Add indexes and migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,16 @@ script:
 psql "$SUPABASE_DATABASE_URL" -f server/db/session-table.sql
 ```
 
+### Migrations
+
+If you change `shared/schema.ts` later (for example to add indexes), generate a
+SQL migration and apply it:
+
+```
+npx drizzle-kit generate --config=drizzle.config.ts
+psql "$SUPABASE_DATABASE_URL" -f migrations/<generated_file>.sql
+```
+
 ## 4. Start the development server
 
 After the variables are set and the schema is applied you can start the app:

--- a/migrations/001_add_indexes.sql
+++ b/migrations/001_add_indexes.sql
@@ -1,0 +1,27 @@
+-- Add frequently-used indexes
+CREATE INDEX IF NOT EXISTS idx_schedule_items_subject_id ON schedule_items (subject_id);
+CREATE INDEX IF NOT EXISTS idx_assignments_created_by ON assignments (created_by);
+CREATE INDEX IF NOT EXISTS idx_assignments_subject_id ON assignments (subject_id);
+CREATE INDEX IF NOT EXISTS idx_enrollments_student_id ON enrollments (student_id);
+CREATE INDEX IF NOT EXISTS idx_enrollments_subject_id ON enrollments (subject_id);
+CREATE INDEX IF NOT EXISTS idx_submissions_assignment_id ON submissions (assignment_id);
+CREATE INDEX IF NOT EXISTS idx_submissions_student_id ON submissions (student_id);
+CREATE INDEX IF NOT EXISTS idx_grades_student_id ON grades (student_id);
+CREATE INDEX IF NOT EXISTS idx_grades_subject_id ON grades (subject_id);
+CREATE INDEX IF NOT EXISTS idx_grades_assignment_id ON grades (assignment_id);
+CREATE INDEX IF NOT EXISTS idx_requests_student_id ON requests (student_id);
+CREATE INDEX IF NOT EXISTS idx_documents_user_id ON documents (user_id);
+CREATE INDEX IF NOT EXISTS idx_documents_created_by ON documents (created_by);
+CREATE INDEX IF NOT EXISTS idx_messages_from_user_id ON messages (from_user_id);
+CREATE INDEX IF NOT EXISTS idx_messages_to_user_id ON messages (to_user_id);
+CREATE INDEX IF NOT EXISTS idx_notifications_user_id ON notifications (user_id);
+CREATE INDEX IF NOT EXISTS idx_courses_specialty_id ON courses (specialty_id);
+CREATE INDEX IF NOT EXISTS idx_groups_course_id ON groups (course_id);
+CREATE INDEX IF NOT EXISTS idx_schedule_entries_group_id ON schedule_entries (group_id);
+CREATE INDEX IF NOT EXISTS idx_schedule_entries_subject_id ON schedule_entries (subject_id);
+CREATE INDEX IF NOT EXISTS idx_schedule_entries_teacher_id ON schedule_entries (teacher_id);
+CREATE INDEX IF NOT EXISTS idx_imported_files_uploaded_by ON imported_files (uploaded_by);
+CREATE INDEX IF NOT EXISTS idx_activity_logs_user_id ON activity_logs (user_id);
+CREATE INDEX IF NOT EXISTS idx_tasks_client_id ON tasks (client_id);
+CREATE INDEX IF NOT EXISTS idx_tasks_executor_id ON tasks (executor_id);
+CREATE INDEX IF NOT EXISTS idx_curriculum_plans_created_by ON curriculum_plans (created_by);

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -31,7 +31,7 @@ export const subjects = pgTable("subjects", {
   name: text("name").notNull(),
   shortName: text("short_name"),
   description: text("description"),
-  teacherId: integer("teacher_id").references(() => users.id),
+  teacherId: integer("teacher_id").references(() => users.id).index(),
   roomNumber: text("room_number"),
   color: text("color"), // Цвет для визуального отображения предмета в расписании
 });
@@ -39,14 +39,14 @@ export const subjects = pgTable("subjects", {
 // Student-Subject Enrollment
 export const enrollments = pgTable("enrollments", {
   id: serial("id").primaryKey(),
-  studentId: integer("student_id").references(() => users.id).notNull(),
-  subjectId: integer("subject_id").references(() => subjects.id).notNull(),
+  studentId: integer("student_id").references(() => users.id).notNull().index(),
+  subjectId: integer("subject_id").references(() => subjects.id).notNull().index(),
 });
 
 // Schedule Items
 export const scheduleItems = pgTable("schedule_items", {
   id: serial("id").primaryKey(),
-  subjectId: integer("subject_id").references(() => subjects.id).notNull(),
+  subjectId: integer("subject_id").references(() => subjects.id).notNull().index(),
   dayOfWeek: integer("day_of_week").notNull(), // 0 = Sunday, 1 = Monday, etc.
   startTime: time("start_time").notNull(),
   endTime: time("end_time").notNull(),
@@ -60,17 +60,17 @@ export const assignments = pgTable("assignments", {
   id: serial("id").primaryKey(),
   title: text("title").notNull(),
   description: text("description"),
-  subjectId: integer("subject_id").references(() => subjects.id).notNull(),
+  subjectId: integer("subject_id").references(() => subjects.id).notNull().index(),
   dueDate: timestamp("due_date").notNull(),
   createdAt: timestamp("created_at").defaultNow(),
-  createdBy: integer("created_by").references(() => users.id).notNull(),
+  createdBy: integer("created_by").references(() => users.id).notNull().index(),
 });
 
 // Assignment Submissions
 export const submissions = pgTable("submissions", {
   id: serial("id").primaryKey(),
-  assignmentId: integer("assignment_id").references(() => assignments.id).notNull(),
-  studentId: integer("student_id").references(() => users.id).notNull(),
+  assignmentId: integer("assignment_id").references(() => assignments.id).notNull().index(),
+  studentId: integer("student_id").references(() => users.id).notNull().index(),
   submittedAt: timestamp("submitted_at").defaultNow(),
   content: text("content"),
   fileUrl: text("file_url"),
@@ -82,9 +82,9 @@ export const submissions = pgTable("submissions", {
 // Student Grades
 export const grades = pgTable("grades", {
   id: serial("id").primaryKey(),
-  studentId: integer("student_id").references(() => users.id).notNull(),
-  subjectId: integer("subject_id").references(() => subjects.id).notNull(),
-  assignmentId: integer("assignment_id").references(() => assignments.id),
+  studentId: integer("student_id").references(() => users.id).notNull().index(),
+  subjectId: integer("subject_id").references(() => subjects.id).notNull().index(),
+  assignmentId: integer("assignment_id").references(() => assignments.id).index(),
   score: integer("score").notNull(),
   maxScore: integer("max_score").notNull(),
   comments: text("comments"),
@@ -95,7 +95,7 @@ export const grades = pgTable("grades", {
 // Student Requests
 export const requests = pgTable("requests", {
   id: serial("id").primaryKey(),
-  studentId: integer("student_id").references(() => users.id).notNull(),
+  studentId: integer("student_id").references(() => users.id).notNull().index(),
   type: text("type").notNull(),
   description: text("description").notNull(),
   status: requestStatusEnum("status").notNull().default('pending'),
@@ -108,19 +108,19 @@ export const requests = pgTable("requests", {
 // Documents (Invoices, Certificates)
 export const documents = pgTable("documents", {
   id: serial("id").primaryKey(),
-  userId: integer("user_id").references(() => users.id).notNull(),
+  userId: integer("user_id").references(() => users.id).notNull().index(),
   title: text("title").notNull(),
   type: text("type").notNull(),
   fileUrl: text("file_url"),
   createdAt: timestamp("created_at").defaultNow(),
-  createdBy: integer("created_by").references(() => users.id),
+  createdBy: integer("created_by").references(() => users.id).index(),
 });
 
 // Chat Messages
 export const messages = pgTable("messages", {
   id: serial("id").primaryKey(),
-  fromUserId: integer("from_user_id").references(() => users.id).notNull(),
-  toUserId: integer("to_user_id").references(() => users.id).notNull(),
+  fromUserId: integer("from_user_id").references(() => users.id).notNull().index(),
+  toUserId: integer("to_user_id").references(() => users.id).notNull().index(),
   content: text("content").notNull(),
   sentAt: timestamp("sent_at").defaultNow(),
   status: messageStatusEnum("status").notNull().default('sent'),
@@ -129,7 +129,7 @@ export const messages = pgTable("messages", {
 // Notifications
 export const notifications = pgTable("notifications", {
   id: serial("id").primaryKey(),
-  userId: integer("user_id").references(() => users.id).notNull(),
+  userId: integer("user_id").references(() => users.id).notNull().index(),
   title: text("title").notNull(),
   content: text("content").notNull(),
   isRead: boolean("is_read").default(false).notNull(),
@@ -153,7 +153,7 @@ export const specialties = pgTable("specialties", {
 export const courses = pgTable("courses", {
   id: serial("id").primaryKey(),
   number: integer("number").notNull(), // номер курса (1, 2, 3, 4 и т.д.)
-  specialtyId: integer("specialty_id").references(() => specialties.id).notNull(),
+  specialtyId: integer("specialty_id").references(() => specialties.id).notNull().index(),
   academicYear: varchar("academic_year", { length: 20 }).notNull(), // учебный год в формате "2023-2024"
   createdAt: timestamp("created_at").defaultNow(),
 });
@@ -162,19 +162,19 @@ export const courses = pgTable("courses", {
 export const groups = pgTable("groups", {
   id: serial("id").primaryKey(),
   name: varchar("name", { length: 50 }).notNull().unique(), // например, "ИП-21-1"
-  courseId: integer("course_id").references(() => courses.id).notNull(),
+  courseId: integer("course_id").references(() => courses.id).notNull().index(),
   createdAt: timestamp("created_at").defaultNow(),
 });
 
 // Записи расписания для групп
 export const scheduleEntries = pgTable("schedule_entries", {
   id: serial("id").primaryKey(),
-  groupId: integer("group_id").references(() => groups.id).notNull(),
+  groupId: integer("group_id").references(() => groups.id).notNull().index(),
   dayOfWeek: dayOfWeekEnum("day_of_week").notNull(),
   startTime: time("start_time").notNull(),
   endTime: time("end_time").notNull(),
-  subjectId: integer("subject_id").references(() => subjects.id).notNull(),
-  teacherId: integer("teacher_id").references(() => users.id),
+  subjectId: integer("subject_id").references(() => subjects.id).notNull().index(),
+  teacherId: integer("teacher_id").references(() => users.id).index(),
   roomNumber: varchar("room_number", { length: 50 }),
   createdAt: timestamp("created_at").defaultNow(),
 });
@@ -192,7 +192,7 @@ export const importedFiles = pgTable("imported_files", {
   itemsCount: integer("items_count").notNull().default(0),
   successCount: integer("success_count").notNull().default(0),
   errorCount: integer("error_count").notNull().default(0),
-  uploadedBy: integer("uploaded_by").references(() => users.id).notNull(),
+  uploadedBy: integer("uploaded_by").references(() => users.id).notNull().index(),
   uploadedAt: timestamp("uploaded_at").defaultNow(),
   errorDetails: text("error_details"),
 });
@@ -202,7 +202,7 @@ export const activityLogs = pgTable("activity_logs", {
   id: serial("id").primaryKey(),
   type: activityTypeEnum("type").notNull(),
   description: text("description").notNull(),
-  userId: integer("user_id").references(() => users.id).notNull(), // Who performed the action
+  userId: integer("user_id").references(() => users.id).notNull().index(), // Who performed the action
   timestamp: timestamp("timestamp").defaultNow(),
   entityId: integer("entity_id"), // ID of the affected entity (file, user, subject, etc.)
   entityType: text("entity_type"), // Type of the affected entity
@@ -219,8 +219,8 @@ export const tasks = pgTable("tasks", {
   dueDate: timestamp("due_date"),
   priority: taskPriorityEnum("priority").notNull().default('medium'),
   status: taskStatusEnum("status").notNull().default('new'),
-  clientId: integer("client_id").references(() => users.id).notNull(), // кто поставил задачу (заказчик)
-  executorId: integer("executor_id").references(() => users.id).notNull(), // кто исполняет задачу
+  clientId: integer("client_id").references(() => users.id).notNull().index(), // кто поставил задачу (заказчик)
+  executorId: integer("executor_id").references(() => users.id).notNull().index(), // кто исполняет задачу
 });
 
 // Учебные планы (Curriculum Plans)
@@ -237,7 +237,7 @@ export const curriculumPlans = pgTable("curriculum_plans", {
   description: text("description"), // Описание учебного плана
   calendarData: text("calendar_data"), // Данные календаря (JSON-строка)
   curriculumPlanData: text("curriculum_plan_data"), // Данные учебного плана (JSON-строка)
-  createdBy: integer("created_by").references(() => users.id), // Кто создал план
+  createdBy: integer("created_by").references(() => users.id).index(), // Кто создал план
   createdAt: timestamp("created_at").defaultNow(),
   updatedAt: timestamp("updated_at").defaultNow(),
 });


### PR DESCRIPTION
## Summary
- index frequently searched foreign keys in `shared/schema.ts`
- add an SQL migration creating the indexes
- describe how to run Drizzle migrations in README

## Testing
- `npm run check`
- `npx drizzle-kit generate --config=drizzle.config.ts` *(fails: esbuild platform mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_684a780081e08320a896de5c0852aa07