### PR TITLE
Add simple caching layer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,5 @@ DATABASE_URL=
 
 # Secret used to sign session cookies
 SESSION_SECRET=change-me
+# Cache TTL in seconds for heavy queries
+CACHE_TTL=60

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "input-otp": "^1.2.4",
     "lucide-react": "^0.453.0",
     "memorystore": "^1.6.7",
+    "node-cache": "^5.1.2",
     "multer": "^1.4.5-lts.2",
     "nanoid": "^5.1.5",
     "node-fetch": "^3.3.2",

--- a/server/db/storage.ts
+++ b/server/db/storage.ts
@@ -10,6 +10,7 @@ import session from 'express-session';
 import createMemoryStore from 'memorystore';
 import pg from 'pg';
 import connectPgSimple from 'connect-pg-simple';
+import { getOrSet } from '../utils/cache';
 
 import * as notificationQueries from './notifications';
 
@@ -186,7 +187,9 @@ export class SupabaseStorage {
 
   // Schedule
   async getScheduleItems(): Promise<ScheduleItem[]> {
-    return db.select().from(schema.scheduleItems);
+    return getOrSet('scheduleItems', async () => {
+      return db.select().from(schema.scheduleItems);
+    });
   }
 
   async getScheduleItem(id: number): Promise<ScheduleItem | undefined> {
@@ -859,9 +862,11 @@ export class SupabaseStorage {
 
   // Методы для работы с учебными планами
   async getCurriculumPlans(): Promise<schema.CurriculumPlan[]> {
-    const plans = await db.select().from(schema.curriculumPlans)
-      .orderBy(desc(schema.curriculumPlans.createdAt));
-    return plans;
+    return getOrSet('curriculumPlans', async () => {
+      const plans = await db.select().from(schema.curriculumPlans)
+        .orderBy(desc(schema.curriculumPlans.createdAt));
+      return plans;
+    });
   }
 
   async getCurriculumPlan(id: number): Promise<schema.CurriculumPlan | undefined> {

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -25,6 +25,7 @@ import * as expressSession from 'express-session';
 import createMemoryStore from "memorystore";
 import PgStoreFactory from 'connect-pg-simple';
 import { logger } from "./utils/logger";
+import { getOrSet } from "./utils/cache";
 
 const MemoryStore = createMemoryStore(session);
 
@@ -464,7 +465,9 @@ export class MemStorage implements IStorage {
   
   // Schedule
   async getScheduleItems(): Promise<ScheduleItem[]> {
-    return Array.from(this.scheduleItems.values());
+    return getOrSet('scheduleItems', async () => {
+      return Array.from(this.scheduleItems.values());
+    });
   }
   
   async getScheduleItem(id: number): Promise<ScheduleItem | undefined> {
@@ -1495,7 +1498,9 @@ export class MemStorage implements IStorage {
   
   // Curriculum Plans
   async getCurriculumPlans(): Promise<CurriculumPlan[]> {
-    return Array.from(this.curriculumPlans.values());
+    return getOrSet('curriculumPlans', async () => {
+      return Array.from(this.curriculumPlans.values());
+    });
   }
 
   async getCurriculumPlan(id: number): Promise<CurriculumPlan | undefined> {

--- a/server/types/node-cache.d.ts
+++ b/server/types/node-cache.d.ts
@@ -1,0 +1,1 @@
+declare module 'node-cache';

--- a/server/utils/cache.ts
+++ b/server/utils/cache.ts
@@ -1,0 +1,15 @@
+import NodeCache from 'node-cache';
+
+const ttl = Number(process.env.CACHE_TTL ?? 60);
+
+export const cache = new NodeCache({ stdTTL: ttl });
+
+export async function getOrSet<T>(key: string, fn: () => Promise<T>): Promise<T> {
+  const cached = cache.get<T>(key);
+  if (cached !== undefined) {
+    return cached;
+  }
+  const result = await fn();
+  cache.set(key, result);
+  return result;
+}


### PR DESCRIPTION
## Summary
- add node-cache dependency and a cache helper
- cache getScheduleItems and getCurriculumPlans
- expose CACHE_TTL env variable

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_684a792a1ee883209eb9756e589329ab