### PR TITLE
Implement centralized error handler middleware

### DIFF
--- a/server/db/users/repository.test.ts
+++ b/server/db/users/repository.test.ts
@@ -37,5 +37,8 @@ const repo = new UsersRepository(fakeDb);
   const updated = await repo.updateUser(1, { password: 'new' });
   assert(updated && updated.password !== 'new');
 
+  const authMissing = await repo.authenticate({ email: 'missing@example.com', password: 'pass' });
+  assert.strictEqual(authMissing, undefined);
+
   console.log('UsersRepository tests passed');
 })();

--- a/server/index.ts
+++ b/server/index.ts
@@ -85,41 +85,9 @@ app.use((req, res, next) => {
     // Register API routes
     const server = await registerRoutes(app);
 
-    // Глобальная обработка ошибок
-    app.use((err: any, _req: Request, res: Response, _next: NextFunction) => {
-      // Логирование ошибки для отладки
-      console.error('Server error caught in global handler:', err);
-
-      // Определяем статус и сообщение в зависимости от типа ошибки
-      let status = err.status || err.statusCode || 500;
-      let message = err.message || "Internal Server Error";
-
-      // Проверка специальных случаев ошибок
-      if (err.code === 'ENOENT') {
-        // Ошибка при отсутствии файла
-        status = 404;
-        message = "Файл не найден";
-      } else if (err.name === 'SyntaxError' && err.message.includes('JSON')) {
-        // Ошибка при разборе JSON
-        status = 400;
-        message = "Неверный формат данных";
-      } else if (err.name === 'MulterError') {
-        // Ошибки связанные с загрузкой файлов через multer
-        status = 400;
-        message = err.message || "Ошибка загрузки файла";
-      }
-
-      // Отправляем ответ с соответствующим статусом и сообщением об ошибке
-      res.status(status).json({
-        message,
-        error: process.env.NODE_ENV === 'development' ? err.stack : undefined
-      });
-
-      // В девелопмент-режиме пробрасываем ошибку дальше для логирования
-      if (process.env.NODE_ENV === 'development') {
-        console.error('Full error details:', err);
-      }
-    });
+    // Error handling middleware
+    const { errorHandler } = await import('./middleware/errorHandler');
+    app.use(errorHandler);
 
     // importantly only setup vite in development and after
     // setting up all the other routes so the catch-all route

--- a/server/middleware/errorHandler.ts
+++ b/server/middleware/errorHandler.ts
@@ -1,0 +1,27 @@
+import { Request, Response, NextFunction } from 'express';
+
+export interface HttpError extends Error {
+  status?: number;
+  details?: unknown;
+}
+
+export function asyncHandler(
+  fn: (req: Request, res: Response, next: NextFunction) => Promise<any>
+) {
+  return function (req: Request, res: Response, next: NextFunction) {
+    Promise.resolve(fn(req, res, next)).catch(next);
+  };
+}
+
+export function errorHandler(
+  err: HttpError,
+  _req: Request,
+  res: Response,
+  _next: NextFunction
+) {
+  const status = err.status ?? 500;
+  const message = err.message || 'Server error';
+  const details = err.details;
+
+  res.status(status).json({ message, details });
+}

--- a/server/routes/activityLogs.ts
+++ b/server/routes/activityLogs.ts
@@ -1,38 +1,42 @@
 import { Express } from "express";
 import { getStorage } from "../storage";
+import { asyncHandler } from "../middleware/errorHandler";
 import type { RouteContext } from "./index";
 
 export function registerActivityLogRoutes(app: Express, { authenticateUser, requireRole }: RouteContext) {
   // Activity Logs Endpoints
-  app.get('/api/activity-logs', authenticateUser, requireRole(['admin']), async (req, res) => {
-    try {
+  app.get(
+    '/api/activity-logs',
+    authenticateUser,
+    requireRole(['admin']),
+    asyncHandler(async (req, res) => {
       const limit = req.query.limit ? parseInt(req.query.limit as string) : 10;
       const logs = await getStorage().getActivityLogs(limit);
       res.json(logs);
-    } catch {
-      res.status(500).json({ message: "Server error" });
-    }
-  });
+    })
+  );
 
-  app.get('/api/activity-logs/type/:type', authenticateUser, requireRole(['admin']), async (req, res) => {
-    try {
+  app.get(
+    '/api/activity-logs/type/:type',
+    authenticateUser,
+    requireRole(['admin']),
+    asyncHandler(async (req, res) => {
       const type = req.params.type;
       const limit = req.query.limit ? parseInt(req.query.limit as string) : 10;
       const logs = await getStorage().getActivityLogsByType(type, limit);
       res.json(logs);
-    } catch {
-      res.status(500).json({ message: "Server error" });
-    }
-  });
+    })
+  );
 
-  app.get('/api/activity-logs/user/:userId', authenticateUser, requireRole(['admin']), async (req, res) => {
-    try {
+  app.get(
+    '/api/activity-logs/user/:userId',
+    authenticateUser,
+    requireRole(['admin']),
+    asyncHandler(async (req, res) => {
       const userId = parseInt(req.params.userId);
       const limit = req.query.limit ? parseInt(req.query.limit as string) : 10;
       const logs = await getStorage().getActivityLogsByUser(userId, limit);
       res.json(logs);
-    } catch {
-      res.status(500).json({ message: "Server error" });
-    }
-  });
+    })
+  );
 }

--- a/server/routes/documents.ts
+++ b/server/routes/documents.ts
@@ -2,58 +2,75 @@ import { Express } from "express";
 import { getStorage } from "../storage";
 import { insertDocumentSchema } from "@shared/schema";
 import { z } from "zod";
+import { asyncHandler } from "../middleware/errorHandler";
 import type { RouteContext } from "./index";
 
 export function registerDocumentRoutes(app: Express, { authenticateUser, requireRole, upload }: RouteContext) {
   // Document Routes
-  app.get('/api/documents/user/:userId', authenticateUser, async (req, res) => {
-    try {
+  app.get(
+    '/api/documents/user/:userId',
+    authenticateUser,
+    asyncHandler(async (req, res) => {
       const userId = parseInt(req.params.userId);
       if (req.user!.id !== userId && req.user!.role === 'student') {
-        return res.status(403).json({ message: "Forbidden" });
+        return res.status(403).json({
+          message: 'Forbidden',
+          details: 'Students can only access their own documents',
+        });
       }
       const documents = await getStorage().getDocumentsByUser(userId);
       res.json(documents);
-    } catch {
-      res.status(500).json({ message: "Server error" });
-    }
-  });
+    })
+  );
 
-  app.get('/api/documents/user/:userId/type/:type', authenticateUser, async (req, res) => {
-    try {
+  app.get(
+    '/api/documents/user/:userId/type/:type',
+    authenticateUser,
+    asyncHandler(async (req, res) => {
       const userId = parseInt(req.params.userId);
       const type = req.params.type;
       if (req.user!.id !== userId && req.user!.role === 'student') {
-        return res.status(403).json({ message: "Forbidden" });
+        return res.status(403).json({
+          message: 'Forbidden',
+          details: 'Students can only access their own documents',
+        });
       }
       const documents = await getStorage().getDocumentsByType(userId, type);
       res.json(documents);
-    } catch {
-      res.status(500).json({ message: "Server error" });
-    }
-  });
+    })
+  );
 
-  app.post('/api/documents', authenticateUser, requireRole(['admin']), upload.single('file'), async (req, res) => {
-    try {
-      const documentData = insertDocumentSchema.parse({
-        ...req.body,
-        createdBy: req.user!.id,
-        fileUrl: req.file ? `/uploads/${req.file.filename}` : null
-      });
+  app.post(
+    '/api/documents',
+    authenticateUser,
+    requireRole(['admin']),
+    upload.single('file'),
+    asyncHandler(async (req, res) => {
+      let documentData;
+      try {
+        documentData = insertDocumentSchema.parse({
+          ...req.body,
+          createdBy: req.user!.id,
+          fileUrl: req.file ? `/uploads/${req.file.filename}` : null,
+        });
+      } catch (error) {
+        if (error instanceof z.ZodError) {
+          const err: any = new Error('Validation error');
+          err.status = 400;
+          err.details = error.errors;
+          throw err;
+        }
+        throw error;
+      }
       const document = await getStorage().createDocument(documentData);
       await getStorage().createNotification({
         userId: documentData.userId,
-        title: "New Document",
+        title: 'New Document',
         content: `A new ${documentData.type} document "${documentData.title}" is available.`,
         relatedId: document.id,
-        relatedType: "document"
+        relatedType: 'document',
       });
       res.status(201).json(document);
-    } catch (error) {
-      if (error instanceof z.ZodError) {
-        return res.status(400).json({ message: "Validation error", errors: error.errors });
-      }
-      res.status(500).json({ message: "Server error" });
-    }
-  });
+    })
+  );
 }


### PR DESCRIPTION
## Summary
- add `errorHandler` and `asyncHandler` helpers
- use middleware in `activityLogs` and `documents` routes
- register middleware in `server/index.ts`
- extend repository test with failing auth scenario

## Testing
- `npx --no-install tsx server/db/users/repository.test.ts` *(fails: platform-specific esbuild)*

------
https://chatgpt.com/codex/tasks/task_e_684a792ce66883208356f1ae56358cbd