### PR TITLE
Update setup instructions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,5 @@ DATABASE_URL=
 SESSION_SECRET=change-me
 # Cache TTL in seconds for heavy queries
 CACHE_TTL=60
+# Log level: info, warn, or error
+LOG_LEVEL=info

--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
 # CampusConnect Setup
 
 This project can store all data in a single Supabase (PostgreSQL) database.
-Follow the steps below to configure the connection.
+Follow the steps below to configure the connection and run the app locally.
 
-## 1. Create a Supabase project
+## 1. Install dependencies
+
+Run `npm install` to install all server and client packages.
+
+## 2. Create a Supabase project
 
 From the Supabase dashboard create a new project and obtain the **connection string**
 for the Postgres database. It should look similar to:
@@ -12,20 +16,22 @@ for the Postgres database. It should look similar to:
 postgresql://USER:PASSWORD@HOST:PORT/DATABASE
 ```
 
-## 2. Configure environment variables
+## 3. Configure environment variables
 
 Create a `.env` file in the project root (you can copy `.env.example`).
-Provide the connection string and a session secret:
+Provide the connection string and a session secret. You can also adjust caching and logging via the variables `CACHE_TTL` and `LOG_LEVEL`.
 
 ```
 SUPABASE_DATABASE_URL=postgresql://USER:PASSWORD@HOST:PORT/DATABASE
 SESSION_SECRET=your-session-secret
+CACHE_TTL=60
+LOG_LEVEL=info
 ```
 
 The `DATABASE_URL` variable is also used by the migration tool. You can set it to
 same value or leave it unset if you only use `SUPABASE_DATABASE_URL`.
 
-## 3. Apply the database schema
+## 4. Apply the database schema
 
 Run the following command once to create all tables in Supabase:
 
@@ -41,6 +47,10 @@ script:
 psql "$SUPABASE_DATABASE_URL" -f server/db/session-table.sql
 ```
 
+## 5. Seed sample data (optional)
+
+Run `npm run db:seed` to apply the migrations and insert demo records.
+
 ### Migrations
 
 If you change `shared/schema.ts` later (for example to add indexes), generate a
@@ -51,12 +61,16 @@ npx drizzle-kit generate --config=drizzle.config.ts
 psql "$SUPABASE_DATABASE_URL" -f migrations/<generated_file>.sql
 ```
 
-## 4. Start the development server
+## 6. Start the development server
 
-After the variables are set and the schema is applied you can start the app:
+After the variables are set and the schema is applied you can start the client and server together or separately:
 
 ```
 npm run dev
+
+# or run them individually
+npm run dev:server
+npm run dev:client
 ```
 
 The server will automatically use `SupabaseStorage` for all data access.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc -p tsconfig.check.json",
-    "db:push": "drizzle-kit push"
+    "db:push": "drizzle-kit push",
+    "db:seed": "tsx server/db/seed.ts"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/server/db/seed.ts
+++ b/server/db/seed.ts
@@ -1,0 +1,6 @@
+import { migrateDatabase, seedDatabase } from './migrations';
+
+(async () => {
+  await migrateDatabase();
+  await seedDatabase();
+})();


### PR DESCRIPTION
## Summary
- document installation and dev usage
- clarify environment variables for cache and logging
- add seed script entry
- show example of using `db:seed`

## Testing
- `npm run check`
- `npm run db:seed` *(fails: esbuild for the wrong platform)*

------
https://chatgpt.com/codex/tasks/task_e_684aadfebca483208c78d8c00e685af0