### PR TITLE
Fix Supabase initialization type

### DIFF
--- a/server/auth.ts
+++ b/server/auth.ts
@@ -47,13 +47,13 @@ export async function initializeDatabase(): Promise<boolean> {
       const dbStorage = new DatabaseStorage();
 
       // Обновляем хранилище через сеттер
-      setStorage(dbStorage);
+      setStorage(dbStorage as unknown as IStorage);
 
       console.log("Database migration completed successfully");
 
       // Проверяем наличие пользователя-администратора
       console.log("Starting database seeding...");
-      const adminUsers = await dbStorage.getAllAdminUsers();
+      const adminUsers = await dbStorage.getUsersByRole('admin');
 
       if (adminUsers.length === 0) {
         console.log("No admin user found, creating one...");


### PR DESCRIPTION
## Summary
- cast Supabase storage to `IStorage` when initializing auth
- use existing `getUsersByRole('admin')` method to seed admin account

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_684ab404926c83209bfc54569b6d3913