### PR TITLE
Fix missing state declarations on TasksPage

### DIFF
--- a/client/src/pages/tasks/Tasks.tsx
+++ b/client/src/pages/tasks/Tasks.tsx
@@ -59,6 +59,13 @@ const TasksPage = () => {
     deleteTaskMutation,
   } = useTasks();
 
+  const [createDialogOpen, setCreateDialogOpen] = useState(false);
+  const [editDialogOpen, setEditDialogOpen] = useState(false);
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [detailDialogOpen, setDetailDialogOpen] = useState(false);
+  const [currentTask, setCurrentTask] = useState<Task | null>(null);
+  const [statusFilter, setStatusFilter] = useState<string | null>(null);
+
   const filteredTasks = statusFilter ? tasks?.filter((task) => task.status === statusFilter) : tasks;
 
   const handleStatusChange = (id: number, status: string) => {


### PR DESCRIPTION
## Summary
- restore local UI state for tasks page

## Testing
- `npx tsc --noEmit`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_684ada3d3cac83208651ad7e1d24aa39