### PR TITLE
Fix task user fetch for non-admins

### DIFF
--- a/client/src/pages/tasks/useTasks.ts
+++ b/client/src/pages/tasks/useTasks.ts
@@ -31,7 +31,7 @@ export function useTasks() {
   const { user } = useAuth();
 
   const { data: users, isLoading: usersLoading } = useQuery<{ id: number; firstName: string; lastName: string; role: string }[]>({
-    queryKey: ['/api/users'],
+    queryKey: [user?.role === 'admin' ? '/api/users' : '/api/users/chat'],
     enabled: !!user,
     staleTime: 1000 * 60 * 5,
   });


### PR DESCRIPTION
## Summary
- allow non-admin users to load assignee options by hitting `/api/users/chat`

## Testing
- `npx --no-install eslint .`


------
https://chatgpt.com/codex/tasks/task_e_684ae693b3f88320a9be10c6926f9297