### PR TITLE
Refactor Tasks page dialogs

### DIFF
--- a/client/src/pages/tasks/CreateTaskDialog.tsx
+++ b/client/src/pages/tasks/CreateTaskDialog.tsx
@@ -1,0 +1,117 @@
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
+import { TextField } from '@/components/forms/TextField';
+import { TextareaField } from '@/components/forms/TextareaField';
+import { SelectField } from '@/components/forms/SelectField';
+import { Calendar } from '@/components/ui/calendar';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { CalendarIcon } from 'lucide-react';
+import { format } from 'date-fns';
+import { cn } from '@/lib/utils';
+import { UseFormReturn } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+import { TaskFormData } from './useTasks';
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  form: UseFormReturn<TaskFormData>;
+  onSubmit: (data: TaskFormData) => void;
+  loading: boolean;
+  users: { id: number; firstName: string; lastName: string; role: string }[] | undefined;
+}
+
+export default function CreateTaskDialog({ open, onOpenChange, form, onSubmit, loading, users }: Props) {
+  const { t } = useTranslation();
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogTrigger asChild>
+        <Button>{t('task.create_new')}</Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-[500px] max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>{t('task.new_task')}</DialogTitle>
+          <DialogDescription>{t('task.new_task_description')}</DialogDescription>
+        </DialogHeader>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <TextField control={form.control} name="title" label={t('task.title')} />
+            <TextareaField control={form.control} name="description" label={t('task.description')} />
+            <div className="grid grid-cols-2 gap-4">
+              <SelectField
+                control={form.control}
+                name="priority"
+                label={t('task.priority.label')}
+                placeholder={t('task.priority.select')}
+                options={[
+                  { value: 'high', label: t('task.priority.high') },
+                  { value: 'medium', label: t('task.priority.medium') },
+                  { value: 'low', label: t('task.priority.low') },
+                ]}
+              />
+              <SelectField
+                control={form.control}
+                name="status"
+                label={t('task.status.label')}
+                placeholder={t('task.status.select')}
+                options={[
+                  { value: 'new', label: t('task.status.new') },
+                  { value: 'in_progress', label: t('task.status.in_progress') },
+                  { value: 'on_hold', label: t('task.status.on_hold') },
+                ]}
+              />
+            </div>
+            <SelectField
+              control={form.control}
+              name="executorId"
+              label={t('task.assignee')}
+              placeholder={t('task.select_assignee')}
+              options={(users || []).map(u => ({
+                value: u.id,
+                label: `${u.firstName} ${u.lastName} (${t(`role.${u.role}`)})`,
+              }))}
+            />
+            <FormField
+              control={form.control}
+              name="dueDate"
+              render={({ field }) => (
+                <FormItem className="flex flex-col">
+                  <FormLabel>{t('task.due_date')}</FormLabel>
+                  <Popover>
+                    <PopoverTrigger asChild>
+                      <FormControl>
+                        <Button
+                          variant="outline"
+                          className={cn('w-full pl-3 text-left font-normal', !field.value && 'text-muted-foreground')}
+                        >
+                          {field.value ? format(field.value, 'PPP') : <span>{t('task.pick_date')}</span>}
+                          <CalendarIcon className="ml-auto h-4 w-4 opacity-50" />
+                        </Button>
+                      </FormControl>
+                    </PopoverTrigger>
+                    <PopoverContent className="w-auto p-0" align="start">
+                      <Calendar
+                        mode="single"
+                        selected={field.value || undefined}
+                        onSelect={field.onChange}
+                        disabled={date => date < new Date(new Date().setHours(0, 0, 0, 0))}
+                        initialFocus
+                      />
+                    </PopoverContent>
+                  </Popover>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <DialogFooter>
+              <Button type="submit" disabled={loading}>{t('task.create')}</Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+

--- a/client/src/pages/tasks/DeleteTaskDialog.tsx
+++ b/client/src/pages/tasks/DeleteTaskDialog.tsx
@@ -1,0 +1,46 @@
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { useTranslation } from 'react-i18next';
+import { Task } from './useTasks';
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  task: Task | null;
+  onConfirm: () => void;
+  loading: boolean;
+}
+
+export default function DeleteTaskDialog({ open, onOpenChange, task, onConfirm, loading }: Props) {
+  const { t } = useTranslation();
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[400px]">
+        <DialogHeader>
+          <DialogTitle>{t('task.delete_task')}</DialogTitle>
+          <DialogDescription>{t('task.confirm_delete')}</DialogDescription>
+        </DialogHeader>
+        <div className="py-4">
+          {task && (
+            <div>
+              <p className="font-semibold">{task.title}</p>
+              <p className="text-sm text-muted-foreground mt-2">
+                {task.description || t('task.no_description')}
+              </p>
+            </div>
+          )}
+        </div>
+        <DialogFooter className="gap-2 sm:gap-0">
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            {t('common.actions.cancel')}
+          </Button>
+          <Button variant="destructive" onClick={onConfirm} disabled={loading}>
+            {t('task.delete_task')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+

--- a/client/src/pages/tasks/EditTaskDialog.tsx
+++ b/client/src/pages/tasks/EditTaskDialog.tsx
@@ -1,0 +1,114 @@
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
+import { TextField } from '@/components/forms/TextField';
+import { TextareaField } from '@/components/forms/TextareaField';
+import { SelectField } from '@/components/forms/SelectField';
+import { Calendar } from '@/components/ui/calendar';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { CalendarIcon } from 'lucide-react';
+import { format } from 'date-fns';
+import { cn } from '@/lib/utils';
+import { UseFormReturn } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+import { TaskFormData } from './useTasks';
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  form: UseFormReturn<TaskFormData>;
+  onSubmit: (data: TaskFormData) => void;
+  loading: boolean;
+  users: { id: number; firstName: string; lastName: string; role: string }[] | undefined;
+}
+
+export default function EditTaskDialog({ open, onOpenChange, form, onSubmit, loading, users }: Props) {
+  const { t } = useTranslation();
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[500px] max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>{t('task.edit_task')}</DialogTitle>
+          <DialogDescription>{t('task.edit_task_description')}</DialogDescription>
+        </DialogHeader>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <TextField control={form.control} name="title" label={t('task.title')} />
+            <TextareaField control={form.control} name="description" label={t('task.description')} />
+            <div className="grid grid-cols-2 gap-4">
+              <SelectField
+                control={form.control}
+                name="priority"
+                label={t('task.priority.label')}
+                placeholder={t('task.priority.select')}
+                options={[
+                  { value: 'high', label: t('task.priority.high') },
+                  { value: 'medium', label: t('task.priority.medium') },
+                  { value: 'low', label: t('task.priority.low') },
+                ]}
+              />
+              <SelectField
+                control={form.control}
+                name="status"
+                label={t('task.status.label')}
+                placeholder={t('task.status.select')}
+                options={[
+                  { value: 'new', label: t('task.status.new') },
+                  { value: 'in_progress', label: t('task.status.in_progress') },
+                  { value: 'on_hold', label: t('task.status.on_hold') },
+                  { value: 'completed', label: t('task.status.completed') },
+                ]}
+              />
+            </div>
+            <SelectField
+              control={form.control}
+              name="executorId"
+              label={t('task.assignee')}
+              placeholder={t('task.select_assignee')}
+              options={(users || []).map(u => ({
+                value: u.id,
+                label: `${u.firstName} ${u.lastName} (${t(`role.${u.role}`)})`,
+              }))}
+            />
+            <FormField
+              control={form.control}
+              name="dueDate"
+              render={({ field }) => (
+                <FormItem className="flex flex-col">
+                  <FormLabel>{t('task.due_date')}</FormLabel>
+                  <Popover>
+                    <PopoverTrigger asChild>
+                      <FormControl>
+                        <Button
+                          variant="outline"
+                          className={cn('w-full pl-3 text-left font-normal', !field.value && 'text-muted-foreground')}
+                        >
+                          {field.value ? format(field.value, 'PPP') : <span>{t('task.pick_date')}</span>}
+                          <CalendarIcon className="ml-auto h-4 w-4 opacity-50" />
+                        </Button>
+                      </FormControl>
+                    </PopoverTrigger>
+                    <PopoverContent className="w-auto p-0" align="start">
+                      <Calendar
+                        mode="single"
+                        selected={field.value || undefined}
+                        onSelect={field.onChange}
+                        initialFocus
+                      />
+                    </PopoverContent>
+                  </Popover>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <DialogFooter>
+              <Button type="submit" disabled={loading}>{t('task.save')}</Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+

--- a/client/src/pages/tasks/TaskDetailsDialog.tsx
+++ b/client/src/pages/tasks/TaskDetailsDialog.tsx
@@ -1,0 +1,113 @@
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { format } from 'date-fns';
+import { useTranslation } from 'react-i18next';
+import { Task } from './useTasks';
+import { useAuth } from '@/hooks/use-auth';
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  task: Task | null;
+  onEdit: (task: Task) => void;
+  onDelete: (task: Task) => void;
+}
+
+export default function TaskDetailsDialog({ open, onOpenChange, task, onEdit, onDelete }: Props) {
+  const { t } = useTranslation();
+  const { user } = useAuth();
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[600px] max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle className="text-xl">{task?.title}</DialogTitle>
+          <div className="flex flex-wrap gap-2 mt-2">
+            {task && (
+              <>
+                {(() => {
+                  switch (task.priority) {
+                    case 'high':
+                      return <Badge variant="outline" className="bg-red-50 text-red-600 border-red-200">{t('task.priority.high')}</Badge>;
+                    case 'medium':
+                      return <Badge variant="outline" className="bg-orange-50 text-orange-600 border-orange-200">{t('task.priority.medium')}</Badge>;
+                    case 'low':
+                      return <Badge variant="outline" className="bg-green-50 text-green-600 border-green-200">{t('task.priority.low')}</Badge>;
+                    default:
+                      return <Badge variant="outline">{task.priority}</Badge>;
+                  }
+                })()}
+                {(() => {
+                  switch (task.status) {
+                    case 'new':
+                      return <Badge variant="outline" className="bg-blue-50 text-blue-600 border-blue-200">{t('task.status.new')}</Badge>;
+                    case 'in_progress':
+                      return <Badge variant="outline" className="bg-yellow-50 text-yellow-600 border-yellow-200">{t('task.status.in_progress')}</Badge>;
+                    case 'completed':
+                      return <Badge variant="outline" className="bg-green-50 text-green-600 border-green-200">{t('task.status.completed')}</Badge>;
+                    case 'on_hold':
+                      return <Badge variant="outline" className="bg-gray-50 text-gray-600 border-gray-200">{t('task.status.on_hold')}</Badge>;
+                    default:
+                      return <Badge variant="outline">{task.status}</Badge>;
+                  }
+                })()}
+              </>
+            )}
+          </div>
+        </DialogHeader>
+        {task && (
+          <div className="py-4 space-y-4">
+            <div>
+              <h3 className="text-sm font-medium text-muted-foreground">{t('task.description')}</h3>
+              <p className="mt-1 whitespace-pre-line">{task.description || t('task.no_description')}</p>
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <h3 className="text-sm font-medium text-muted-foreground">{t('task.client')}</h3>
+                <p className="font-medium">
+                  {task.client ? `${task.client.firstName} ${task.client.lastName}` : t('task.not_assigned')}
+                </p>
+              </div>
+              <div>
+                <h3 className="text-sm font-medium text-muted-foreground">{t('task.executor')}</h3>
+                <p className="font-medium">
+                  {task.executor ? `${task.executor.firstName} ${task.executor.lastName}` : t('task.not_assigned')}
+                </p>
+              </div>
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <h3 className="text-sm font-medium text-muted-foreground">{t('task.created')}</h3>
+                <p className="font-medium">{format(new Date(task.createdAt), 'PPP, HH:mm')}</p>
+              </div>
+              <div>
+                <h3 className="text-sm font-medium text-muted-foreground">{t('task.updated')}</h3>
+                <p className="font-medium">{format(new Date(task.updatedAt), 'PPP, HH:mm')}</p>
+              </div>
+            </div>
+            {task.dueDate && (
+              <div>
+                <h3 className="text-sm font-medium text-muted-foreground">{t('task.due_date')}</h3>
+                <p className="font-medium">{format(new Date(task.dueDate), 'PPP')}</p>
+              </div>
+            )}
+            <div className="pt-2">
+              <p className="text-xs text-muted-foreground">ID: {task.id}</p>
+            </div>
+          </div>
+        )}
+        <DialogFooter className="gap-2">
+          {task && (user?.id === task.clientId || user?.role === 'admin') && (
+            <>
+              <Button variant="outline" onClick={() => task && onEdit(task)}>{t('task.edit_task')}</Button>
+              <Button variant="destructive" onClick={() => task && onDelete(task)}>{t('task.delete_task')}</Button>
+            </>
+          )}
+          <Button onClick={() => onOpenChange(false)}>{t('common.close')}</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+

--- a/client/src/pages/tasks/Tasks.tsx
+++ b/client/src/pages/tasks/Tasks.tsx
@@ -3,41 +3,13 @@ import { useTranslation } from 'react-i18next';
 import { useAuth } from '@/hooks/use-auth';
 
 
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from '@/components/ui/dialog';
-import { 
-  Form, 
-  FormControl, 
-  FormField, 
-  FormItem, 
-  FormLabel, 
-  FormMessage 
-} from '@/components/ui/form';
 import { Button } from '@/components/ui/button';
-import { TextField } from '@/components/forms/TextField';
-import { TextareaField } from '@/components/forms/TextareaField';
-import { SelectField } from '@/components/forms/SelectField';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
-import { Badge } from '@/components/ui/badge';
-import { Calendar } from '@/components/ui/calendar';
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
-import { format } from 'date-fns';
-import { CalendarIcon, CheckCircle, Clock, AlertCircle, PauseCircle } from 'lucide-react';
-import { cn } from '@/lib/utils';
+import { CheckCircle, Clock, AlertCircle, PauseCircle } from 'lucide-react';
 import TaskCard from '@/components/tasks/TaskCard';
+import CreateTaskDialog from './CreateTaskDialog';
+import EditTaskDialog from './EditTaskDialog';
+import DeleteTaskDialog from './DeleteTaskDialog';
+import TaskDetailsDialog from './TaskDetailsDialog';
 import { useTasks, Task, TaskFormData } from './useTasks';
 
 // Основной компонент страницы задач
@@ -136,374 +108,43 @@ const TasksPage = () => {
     <div className="container py-8 px-8">
       <div className="flex justify-between items-center mb-6">
         <h1 className="text-2xl font-bold font-heading">{t('task.manager')}</h1>
-        <Dialog open={createDialogOpen} onOpenChange={setCreateDialogOpen}>
-          <DialogTrigger asChild>
-            <Button>{t('task.create_new')}</Button>
-          </DialogTrigger>
-          <DialogContent className="sm:max-w-[500px] max-h-[90vh] overflow-y-auto">
-            <DialogHeader>
-              <DialogTitle>{t('task.new_task')}</DialogTitle>
-              <DialogDescription>
-                {t('task.new_task_description')}
-              </DialogDescription>
-            </DialogHeader>
-            <Form {...form}>
-              <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
-                <TextField control={form.control} name="title" label={t('task.title')} />
-                
-                <TextareaField control={form.control} name="description" label={t('task.description')} />
-                
-                <div className="grid grid-cols-2 gap-4">
-                  <SelectField
-                    control={form.control}
-                    name="priority"
-                    label={t('task.priority.label')}
-                    placeholder={t('task.priority.select')}
-                    options={[
-                      { value: 'high', label: t('task.priority.high') },
-                      { value: 'medium', label: t('task.priority.medium') },
-                      { value: 'low', label: t('task.priority.low') }
-                    ]}
-                  />
-                  
-                  <SelectField
-                    control={form.control}
-                    name="status"
-                    label={t('task.status.label')}
-                    placeholder={t('task.status.select')}
-                    options={[
-                      { value: 'new', label: t('task.status.new') },
-                      { value: 'in_progress', label: t('task.status.in_progress') },
-                      { value: 'on_hold', label: t('task.status.on_hold') }
-                    ]}
-                  />
-                </div>
-                
-                <SelectField
-                  control={form.control}
-                  name="executorId"
-                  label={t('task.assignee')}
-                  placeholder={t('task.select_assignee')}
-                  options={(users || []).map(u => ({
-                    value: u.id,
-                    label: `${u.firstName} ${u.lastName} (${t(`role.${u.role}`)})`
-                  }))}
-                />
-                
-                <FormField
-                  control={form.control}
-                  name="dueDate"
-                  render={({ field }) => (
-                    <FormItem className="flex flex-col">
-                      <FormLabel>{t('task.due_date')}</FormLabel>
-                      <Popover>
-                        <PopoverTrigger asChild>
-                          <FormControl>
-                            <Button
-                              variant={"outline"}
-                              className={cn(
-                                "w-full pl-3 text-left font-normal",
-                                !field.value && "text-muted-foreground"
-                              )}
-                            >
-                              {field.value ? (
-                                format(field.value, "PPP")
-                              ) : (
-                                <span>{t('task.pick_date')}</span>
-                              )}
-                              <CalendarIcon className="ml-auto h-4 w-4 opacity-50" />
-                            </Button>
-                          </FormControl>
-                        </PopoverTrigger>
-                        <PopoverContent className="w-auto p-0" align="start">
-                          <Calendar
-                            mode="single"
-                            selected={field.value || undefined}
-                            onSelect={field.onChange}
-                            disabled={(date) =>
-                              date < new Date(new Date().setHours(0, 0, 0, 0))
-                            }
-                            initialFocus
-                          />
-                        </PopoverContent>
-                      </Popover>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                
-                <DialogFooter>
-                  <Button type="submit" disabled={createTaskMutation.isPending}>{t('task.create')}</Button>
-                </DialogFooter>
-              </form>
-            </Form>
-          </DialogContent>
-        </Dialog>
+        <CreateTaskDialog
+          open={createDialogOpen}
+          onOpenChange={setCreateDialogOpen}
+          form={form}
+          onSubmit={onSubmit}
+          loading={createTaskMutation.isPending}
+          users={users}
+        />
       </div>
 
-      {/* Диалог редактирования задачи */}
-      <Dialog open={editDialogOpen} onOpenChange={setEditDialogOpen}>
-        <DialogContent className="sm:max-w-[500px] max-h-[90vh] overflow-y-auto">
-          <DialogHeader>
-            <DialogTitle>{t('task.edit_task')}</DialogTitle>
-            <DialogDescription>
-              {t('task.edit_task_description')}
-            </DialogDescription>
-          </DialogHeader>
-          <Form {...editForm}>
-            <form onSubmit={editForm.handleSubmit(onEditSubmit)} className="space-y-4">
-              <TextField control={editForm.control} name="title" label={t('task.title')} />
-              
-              <TextareaField control={editForm.control} name="description" label={t('task.description')} />
-              
-              <div className="grid grid-cols-2 gap-4">
-                <SelectField
-                  control={editForm.control}
-                  name="priority"
-                  label={t('task.priority.label')}
-                  placeholder={t('task.priority.select')}
-                  options={[
-                    { value: 'high', label: t('task.priority.high') },
-                    { value: 'medium', label: t('task.priority.medium') },
-                    { value: 'low', label: t('task.priority.low') }
-                  ]}
-                />
-                
-                <SelectField
-                  control={editForm.control}
-                  name="status"
-                  label={t('task.status.label')}
-                  placeholder={t('task.status.select')}
-                  options={[
-                    { value: 'new', label: t('task.status.new') },
-                    { value: 'in_progress', label: t('task.status.in_progress') },
-                    { value: 'on_hold', label: t('task.status.on_hold') },
-                    { value: 'completed', label: t('task.status.completed') }
-                  ]}
-                />
-              </div>
-              
-              <SelectField
-                control={editForm.control}
-                name="executorId"
-                label={t('task.assignee')}
-                placeholder={t('task.select_assignee')}
-                options={(users || []).map(u => ({
-                  value: u.id,
-                  label: `${u.firstName} ${u.lastName} (${t(`role.${u.role}`)})`
-                }))}
-              />
-              
-              <FormField
-                control={editForm.control}
-                name="dueDate"
-                render={({ field }) => (
-                  <FormItem className="flex flex-col">
-                    <FormLabel>{t('task.due_date')}</FormLabel>
-                    <Popover>
-                      <PopoverTrigger asChild>
-                        <FormControl>
-                          <Button
-                            variant={"outline"}
-                            className={cn(
-                              "w-full pl-3 text-left font-normal",
-                              !field.value && "text-muted-foreground"
-                            )}
-                          >
-                            {field.value ? (
-                              format(field.value, "PPP")
-                            ) : (
-                              <span>{t('task.pick_date')}</span>
-                            )}
-                            <CalendarIcon className="ml-auto h-4 w-4 opacity-50" />
-                          </Button>
-                        </FormControl>
-                      </PopoverTrigger>
-                      <PopoverContent className="w-auto p-0" align="start">
-                        <Calendar
-                          mode="single"
-                          selected={field.value || undefined}
-                          onSelect={field.onChange}
-                          initialFocus
-                        />
-                      </PopoverContent>
-                    </Popover>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              
-              <DialogFooter>
-                <Button type="submit" disabled={updateTaskMutation.isPending}>{t('task.save')}</Button>
-              </DialogFooter>
-            </form>
-          </Form>
-        </DialogContent>
-      </Dialog>
+        {/* Диалог редактирования задачи */}
+        <EditTaskDialog
+          open={editDialogOpen}
+          onOpenChange={setEditDialogOpen}
+          form={editForm}
+          onSubmit={onEditSubmit}
+          loading={updateTaskMutation.isPending}
+          users={users}
+        />
 
-      {/* Диалог подтверждения удаления задачи */}
-      <Dialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
-        <DialogContent className="sm:max-w-[400px]">
-          <DialogHeader>
-            <DialogTitle>{t('task.delete_task')}</DialogTitle>
-            <DialogDescription>
-              {t('task.confirm_delete')}
-            </DialogDescription>
-          </DialogHeader>
-          <div className="py-4">
-            {currentTask && (
-              <div>
-                <p className="font-semibold">{currentTask.title}</p>
-                <p className="text-sm text-muted-foreground mt-2">
-                  {currentTask.description || t('task.no_description')}
-                </p>
-              </div>
-            )}
-          </div>
-          <DialogFooter className="gap-2 sm:gap-0">
-            <Button
-              variant="outline"
-              onClick={() => setDeleteDialogOpen(false)}
-            >
-              {t('common.actions.cancel')}
-            </Button>
-            <Button
-              variant="destructive"
-              onClick={handleDeleteConfirm}
-              disabled={deleteTaskMutation.isPending}
-            >
-              {t('task.delete_task')}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+        {/* Диалог подтверждения удаления задачи */}
+        <DeleteTaskDialog
+          open={deleteDialogOpen}
+          onOpenChange={setDeleteDialogOpen}
+          task={currentTask}
+          onConfirm={handleDeleteConfirm}
+          loading={deleteTaskMutation.isPending}
+        />
       
-      {/* Диалог просмотра деталей задачи */}
-      <Dialog open={detailDialogOpen} onOpenChange={setDetailDialogOpen}>
-        <DialogContent className="sm:max-w-[600px] max-h-[90vh] overflow-y-auto">
-          <DialogHeader>
-            <DialogTitle className="text-xl">
-              {currentTask?.title}
-            </DialogTitle>
-            <div className="flex flex-wrap gap-2 mt-2">
-              {currentTask && (
-                <>
-                  {(() => {
-                    switch (currentTask.priority) {
-                      case 'high':
-                        return <Badge variant="outline" className="bg-red-50 text-red-600 border-red-200">{t('task.priority.high')}</Badge>;
-                      case 'medium':
-                        return <Badge variant="outline" className="bg-orange-50 text-orange-600 border-orange-200">{t('task.priority.medium')}</Badge>;
-                      case 'low':
-                        return <Badge variant="outline" className="bg-green-50 text-green-600 border-green-200">{t('task.priority.low')}</Badge>;
-                      default:
-                        return <Badge variant="outline">{currentTask.priority}</Badge>;
-                    }
-                  })()}
-                  {(() => {
-                    switch (currentTask.status) {
-                      case 'new':
-                        return <Badge variant="outline" className="bg-blue-50 text-blue-600 border-blue-200">{t('task.status.new')}</Badge>;
-                      case 'in_progress':
-                        return <Badge variant="outline" className="bg-yellow-50 text-yellow-600 border-yellow-200">{t('task.status.in_progress')}</Badge>;
-                      case 'completed':
-                        return <Badge variant="outline" className="bg-green-50 text-green-600 border-green-200">{t('task.status.completed')}</Badge>;
-                      case 'on_hold':
-                        return <Badge variant="outline" className="bg-gray-50 text-gray-600 border-gray-200">{t('task.status.on_hold')}</Badge>;
-                      default:
-                        return <Badge variant="outline">{currentTask.status}</Badge>;
-                    }
-                  })()}
-                </>
-              )}
-            </div>
-          </DialogHeader>
-          
-          {currentTask && (
-            <div className="py-4 space-y-4">
-              <div>
-                <h3 className="text-sm font-medium text-muted-foreground">{t('task.description')}</h3>
-                <p className="mt-1 whitespace-pre-line">
-                  {currentTask.description || t('task.no_description')}
-                </p>
-              </div>
-              
-              <div className="grid grid-cols-2 gap-4">
-                <div>
-                  <h3 className="text-sm font-medium text-muted-foreground">{t('task.client')}</h3>
-                  <p className="font-medium">
-                    {currentTask.client 
-                      ? `${currentTask.client.firstName} ${currentTask.client.lastName}` 
-                      : t('task.not_assigned')}
-                  </p>
-                </div>
-                
-                <div>
-                  <h3 className="text-sm font-medium text-muted-foreground">{t('task.executor')}</h3>
-                  <p className="font-medium">
-                    {currentTask.executor 
-                      ? `${currentTask.executor.firstName} ${currentTask.executor.lastName}` 
-                      : t('task.not_assigned')}
-                  </p>
-                </div>
-              </div>
-              
-              <div className="grid grid-cols-2 gap-4">
-                <div>
-                  <h3 className="text-sm font-medium text-muted-foreground">{t('task.created')}</h3>
-                  <p className="font-medium">{format(new Date(currentTask.createdAt), 'PPP, HH:mm')}</p>
-                </div>
-                
-                <div>
-                  <h3 className="text-sm font-medium text-muted-foreground">{t('task.updated')}</h3>
-                  <p className="font-medium">{format(new Date(currentTask.updatedAt), 'PPP, HH:mm')}</p>
-                </div>
-              </div>
-              
-              {currentTask.dueDate && (
-                <div>
-                  <h3 className="text-sm font-medium text-muted-foreground">{t('task.due_date')}</h3>
-                  <p className="font-medium">{format(new Date(currentTask.dueDate), 'PPP')}</p>
-                </div>
-              )}
-              
-              <div className="pt-2">
-                <p className="text-xs text-muted-foreground">
-                  ID: {currentTask.id}
-                </p>
-              </div>
-            </div>
-          )}
-          
-          <DialogFooter className="gap-2">
-            {currentTask && (user?.id === currentTask.clientId || user?.role === 'admin') && (
-              <>
-                <Button 
-                  variant="outline"
-                  onClick={() => {
-                    setDetailDialogOpen(false);
-                    handleEditClick(currentTask);
-                  }}
-                >
-                  {t('task.edit_task')}
-                </Button>
-                <Button 
-                  variant="destructive"
-                  onClick={() => {
-                    setDetailDialogOpen(false);
-                    handleDeleteClick(currentTask);
-                  }}
-                >
-                  {t('task.delete_task')}
-                </Button>
-              </>
-            )}
-            <Button onClick={() => setDetailDialogOpen(false)}>
-              {t('common.close')}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+        {/* Диалог просмотра деталей задачи */}
+        <TaskDetailsDialog
+          open={detailDialogOpen}
+          onOpenChange={setDetailDialogOpen}
+          task={currentTask}
+          onEdit={handleEditClick}
+          onDelete={handleDeleteClick}
+        />
 
       {/* Фильтры */}
       <div className="mb-6">


### PR DESCRIPTION
## Summary
- extract task-related dialogs into separate components for easier maintenance
- remove unused imports after refactor

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_684aecb82e7083208833b12b56bf283d