### PR TITLE
Fix teacher dashboard queries

### DIFF
--- a/client/src/components/dashboards/TeacherDashboard.tsx
+++ b/client/src/components/dashboards/TeacherDashboard.tsx
@@ -23,25 +23,28 @@ const TeacherDashboard = () => {
   const { user } = useAuth();
   const { t } = useTranslation();
   
+  const isAdmin = user?.role === 'admin';
+
   // Get teacher's classes/subjects
   const { data: subjects = [] } = useQuery<Subject[]>({
-    queryKey: [`/api/subjects/teacher/${user?.id}`],
+    queryKey: ['/api/subjects/teacher'],
   });
-  
+
   // Get teacher's schedule
   const { data: scheduleItems = [] } = useQuery<ScheduleItemWithSubject[]>({
-    queryKey: [`/api/schedule/teacher/${user?.id}`],
+    queryKey: ['/api/schedule/teacher'],
   });
-  
+
   // Get teacher's assignments
   const { data: assignments = [] } = useQuery<Assignment[]>({
-    queryKey: [`/api/assignments/teacher/${user?.id}`],
+    queryKey: ['/api/assignments/teacher'],
   });
-  
+
   // Get all students for teacher's classes
   const { data: allStudents = [] } = useQuery<User[]>({
     queryKey: ['/api/users'],
     select: (data) => data.filter(user => user.role === 'student'),
+    enabled: isAdmin,
   });
   
   // Get notifications


### PR DESCRIPTION
## Summary
- update teacher dashboard queries to use role-safe endpoints

## Testing
- `npm run check`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684aef225e6c8320b7673f9f44888472