### PR TITLE
Fix create task dialog open handler

### DIFF
--- a/client/src/pages/tasks/CreateTaskDialog.tsx
+++ b/client/src/pages/tasks/CreateTaskDialog.tsx
@@ -28,7 +28,9 @@ export default function CreateTaskDialog({ open, onOpenChange, form, onSubmit, l
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogTrigger asChild>
-        <Button>{t('task.create_new')}</Button>
+        <Button onClick={() => onOpenChange(true)} type="button">
+          {t('task.create_new')}
+        </Button>
       </DialogTrigger>
       <DialogContent className="sm:max-w-[500px] max-h-[90vh] overflow-y-auto">
         <DialogHeader>


### PR DESCRIPTION
## Summary
- make create task button explicitly open the dialog

## Testing
- `npm run check`
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_684af0a7cc108320afcda50fcfa6985c