### PR TITLE
Add API 404 middleware

### DIFF
--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -263,7 +263,12 @@ export async function registerRoutes(app: Express): Promise<Server> {
   registerNotificationRoutes(app, ctx);
   registerActivityLogRoutes(app, ctx);
   registerCurriculumRoutes(app, ctx);
-  
+
+  // Handle unknown /api routes with JSON 404
+  app.use('/api', (_req, res) => {
+    res.status(404).json({ message: 'API endpoint not found' });
+  });
+
   return httpServer;
 }
 


### PR DESCRIPTION
## Summary
- ensure missing /api routes return JSON 404

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_684af24bd3bc83208ceb100f78e95837