### PR TITLE
Add route for teacher subjects

### DIFF
--- a/client/src/components/dashboards/TeacherDashboard.tsx
+++ b/client/src/components/dashboards/TeacherDashboard.tsx
@@ -27,7 +27,8 @@ const TeacherDashboard = () => {
 
   // Get teacher's classes/subjects
   const { data: subjects = [] } = useQuery<Subject[]>({
-    queryKey: ['/api/subjects/teacher'],
+    queryKey: [`/api/subjects/teacher/${user?.id}`],
+    enabled: !!user?.id,
   });
 
   // Get teacher's schedule

--- a/client/src/pages/assignments/useAssignments.ts
+++ b/client/src/pages/assignments/useAssignments.ts
@@ -37,9 +37,9 @@ export function useAssignments() {
   });
 
   const { data: subjects } = useQuery({
-    queryKey: ['/api/subjects/teacher'],
+    queryKey: [`/api/subjects/teacher/${user?.id}`],
     queryFn: async () => {
-      const response = await fetch('/api/subjects/teacher');
+      const response = await fetch(`/api/subjects/teacher/${user!.id}`);
       if (!response.ok) throw new Error('Failed to fetch subjects');
       return await response.json();
     },

--- a/server/routes/schedule.ts
+++ b/server/routes/schedule.ts
@@ -56,13 +56,36 @@ app.get('/api/subjects/teacher', authenticateUser, async (req, res) => {
     if (!req.user || (req.user!.role !== 'teacher' && req.user!.role !== 'admin')) {
       return res.status(403).json({ message: "Access denied" });
     }
-    
+
     const subjects = await getStorage().getSubjectsByTeacher(req.user!.id);
     res.json(subjects);
   } catch (error) {
     res.status(500).json({ message: "Server error" });
   }
 });
+
+  // Get subjects taught by a specific teacher
+  app.get('/api/subjects/teacher/:teacherId', authenticateUser, async (req, res) => {
+    try {
+      const teacherId = parseInt(req.params.teacherId);
+
+      // Ensure the teacher exists
+      const teacher = await getStorage().getUser(teacherId);
+      if (!teacher || teacher.role !== 'teacher') {
+        return res.status(404).json({ message: "Teacher not found" });
+      }
+
+      // Allow only the requested teacher or admins
+      if (req.user!.id !== teacherId && req.user!.role !== 'admin') {
+        return res.status(403).json({ message: "Forbidden" });
+      }
+
+      const subjects = await getStorage().getSubjectsByTeacher(teacherId);
+      res.json(subjects);
+    } catch (error) {
+      res.status(500).json({ message: "Server error" });
+    }
+  });
 
 app.post('/api/subjects', authenticateUser, requireRole(['admin']), async (req, res) => {
   try {


### PR DESCRIPTION
## Summary
- add API to fetch subjects by teacher id
- use new API route in TeacherDashboard and assignments hook

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_684af24a35b48320b2531a3e51ee5df6