### PR TITLE
Refactor task badges

### DIFF
--- a/client/src/components/tasks/TaskBadges.tsx
+++ b/client/src/components/tasks/TaskBadges.tsx
@@ -1,0 +1,69 @@
+import { Badge } from '@/components/ui/badge';
+import { useTranslation } from 'react-i18next';
+
+interface StatusBadgeProps {
+  status: string;
+}
+
+export function StatusBadge({ status }: StatusBadgeProps) {
+  const { t } = useTranslation();
+  const map: Record<string, { label: string; className: string }> = {
+    new: {
+      label: t('task.status.new'),
+      className:
+        'bg-blue-100/70 text-blue-700 border-blue-200 dark:bg-blue-950/50 dark:text-blue-400 dark:border-blue-800',
+    },
+    in_progress: {
+      label: t('task.status.in_progress'),
+      className:
+        'bg-amber-100/70 text-amber-700 border-amber-200 dark:bg-amber-950/50 dark:text-amber-400 dark:border-amber-800',
+    },
+    completed: {
+      label: t('task.status.completed'),
+      className:
+        'bg-green-100/70 text-green-700 border-green-200 dark:bg-green-950/50 dark:text-green-400 dark:border-green-800',
+    },
+    on_hold: {
+      label: t('task.status.on_hold'),
+      className:
+        'bg-gray-100/70 text-gray-700 border-gray-200 dark:bg-gray-800/50 dark:text-gray-400 dark:border-gray-700',
+    },
+  };
+  const info = map[status];
+  return (
+    <Badge variant="outline" className={info?.className}>
+      {info ? info.label : status}
+    </Badge>
+  );
+}
+
+interface PriorityBadgeProps {
+  priority: string;
+}
+
+export function PriorityBadge({ priority }: PriorityBadgeProps) {
+  const { t } = useTranslation();
+  const map: Record<string, { label: string; className: string }> = {
+    high: {
+      label: t('task.priority.high'),
+      className:
+        'bg-red-100/70 text-red-700 border-red-200 dark:bg-red-950/50 dark:text-red-400 dark:border-red-800',
+    },
+    medium: {
+      label: t('task.priority.medium'),
+      className:
+        'bg-orange-100/70 text-orange-700 border-orange-200 dark:bg-orange-950/50 dark:text-orange-400 dark:border-orange-800',
+    },
+    low: {
+      label: t('task.priority.low'),
+      className:
+        'bg-green-100/70 text-green-700 border-green-200 dark:bg-green-950/50 dark:text-green-400 dark:border-green-800',
+    },
+  };
+  const info = map[priority];
+  return (
+    <Badge variant="outline" className={info?.className}>
+      {info ? info.label : priority}
+    </Badge>
+  );
+}

--- a/client/src/components/tasks/TaskCard.tsx
+++ b/client/src/components/tasks/TaskCard.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '@/hooks/use-auth';
-import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+import { StatusBadge, PriorityBadge } from './TaskBadges';
 import { Button } from '@/components/ui/button';
 import {
   Select,
@@ -29,61 +29,6 @@ const TaskCard = ({ task, onStatusChange, onEditClick, onDeleteClick, onViewDeta
   const isCreator = isClient;
   const isAdmin = user?.role === 'admin';
 
-  const getStatusBadge = (status: string) => {
-    switch (status) {
-      case 'new':
-        return (
-          <Badge variant="outline" className="bg-blue-100/70 text-blue-700 border-blue-200 dark:bg-blue-950/50 dark:text-blue-400 dark:border-blue-800">
-            {t('task.status.new')}
-          </Badge>
-        );
-      case 'in_progress':
-        return (
-          <Badge variant="outline" className="bg-amber-100/70 text-amber-700 border-amber-200 dark:bg-amber-950/50 dark:text-amber-400 dark:border-amber-800">
-            {t('task.status.in_progress')}
-          </Badge>
-        );
-      case 'completed':
-        return (
-          <Badge variant="outline" className="bg-green-100/70 text-green-700 border-green-200 dark:bg-green-950/50 dark:text-green-400 dark:border-green-800">
-            {t('task.status.completed')}
-          </Badge>
-        );
-      case 'on_hold':
-        return (
-          <Badge variant="outline" className="bg-gray-100/70 text-gray-700 border-gray-200 dark:bg-gray-800/50 dark:text-gray-400 dark:border-gray-700">
-            {t('task.status.on_hold')}
-          </Badge>
-        );
-      default:
-        return <Badge variant="outline">{status}</Badge>;
-    }
-  };
-
-  const getPriorityBadge = (priority: string) => {
-    switch (priority) {
-      case 'high':
-        return (
-          <Badge variant="outline" className="bg-red-100/70 text-red-700 border-red-200 dark:bg-red-950/50 dark:text-red-400 dark:border-red-800">
-            {t('task.priority.high')}
-          </Badge>
-        );
-      case 'medium':
-        return (
-          <Badge variant="outline" className="bg-orange-100/70 text-orange-700 border-orange-200 dark:bg-orange-950/50 dark:text-orange-400 dark:border-orange-800">
-            {t('task.priority.medium')}
-          </Badge>
-        );
-      case 'low':
-        return (
-          <Badge variant="outline" className="bg-green-100/70 text-green-700 border-green-200 dark:bg-green-950/50 dark:text-green-400 dark:border-green-800">
-            {t('task.priority.low')}
-          </Badge>
-        );
-      default:
-        return <Badge variant="outline">{priority}</Badge>;
-    }
-  };
 
   const handleCardClick = (e: React.MouseEvent) => {
     if (e.target instanceof HTMLElement && (e.target.closest('button') || e.target.closest('[role="combobox"]'))) {
@@ -103,8 +48,8 @@ const TaskCard = ({ task, onStatusChange, onEditClick, onDeleteClick, onViewDeta
             {task.title}
           </CardTitle>
           <div className="flex gap-1">
-            {getPriorityBadge(task.priority)}
-            {getStatusBadge(task.status)}
+            <PriorityBadge priority={task.priority} />
+            <StatusBadge status={task.status} />
           </div>
         </div>
       </CardHeader>

--- a/client/src/components/tasks/TaskDetailsModal.tsx
+++ b/client/src/components/tasks/TaskDetailsModal.tsx
@@ -4,7 +4,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { format } from 'date-fns';
 import { ru } from 'date-fns/locale';
 import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
+import { StatusBadge, PriorityBadge } from './TaskBadges';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
 import { apiRequest } from '@/lib/queryClient';
 import { useToast } from '@/hooks/use-toast';
@@ -49,49 +49,7 @@ const TaskDetailsModal: React.FC<TaskDetailsModalProps> = ({
   const { user } = useAuth();
   const [isUpdating, setIsUpdating] = useState(false);
   
-  // Получение статуса задачи в виде текста
-  const getStatusText = (status: string) => {
-    switch (status) {
-      case 'in_progress': 
-        return t('task.status.inProgress', 'В процессе');
-      case 'completed': 
-        return t('task.status.completed', 'Выполнено');
-      case 'on_hold': 
-        return t('task.status.onHold', 'На паузе');
-      default: 
-        return t('task.status.new', 'Новая');
-    }
-  };
 
-  // Получение класса для статуса
-  const getStatusBadgeClass = (status: string) => {
-    switch (status) {
-      case 'new':
-        return "bg-blue-50 text-blue-600 border-blue-200 dark:bg-blue-950/50 dark:text-blue-400 dark:border-blue-800";
-      case 'in_progress':
-        return "bg-yellow-50 text-yellow-600 border-yellow-200 dark:bg-yellow-950/50 dark:text-yellow-400 dark:border-yellow-800";
-      case 'completed':
-        return "bg-green-50 text-green-600 border-green-200 dark:bg-green-950/50 dark:text-green-400 dark:border-green-800";
-      case 'on_hold':
-        return "bg-gray-50 text-gray-600 border-gray-200 dark:bg-gray-800/50 dark:text-gray-400 dark:border-gray-700";
-      default:
-        return "";
-    }
-  };
-  
-  // Получение класса для приоритета
-  const getPriorityBadgeClass = (priority: string = 'medium') => {
-    switch (priority) {
-      case 'high':
-        return "bg-red-50 text-red-600 border-red-200 dark:bg-red-950/50 dark:text-red-400 dark:border-red-800";
-      case 'medium':
-        return "bg-orange-50 text-orange-600 border-orange-200 dark:bg-orange-950/50 dark:text-orange-400 dark:border-orange-800";
-      case 'low':
-        return "bg-green-50 text-green-600 border-green-200 dark:bg-green-950/50 dark:text-green-400 dark:border-green-800";
-      default:
-        return "";
-    }
-  };
 
   // Форматирование даты
   const formatDateString = (dateString?: string) => {
@@ -175,17 +133,8 @@ const TaskDetailsModal: React.FC<TaskDetailsModalProps> = ({
             {task.title}
           </DialogTitle>
           <div className="flex flex-wrap gap-2 mt-2">
-            {task.priority && (
-              <Badge variant="outline" className={getPriorityBadgeClass(task.priority)}>
-                {task.priority === 'high' ? t('task.priority.high', 'Высокий') :
-                 task.priority === 'medium' ? t('task.priority.medium', 'Средний') :
-                 t('task.priority.low', 'Низкий')}
-              </Badge>
-            )}
-            
-            <Badge variant="outline" className={getStatusBadgeClass(task.status)}>
-              {getStatusText(task.status)}
-            </Badge>
+            {task.priority && <PriorityBadge priority={task.priority} />}
+            <StatusBadge status={task.status} />
           </div>
         </DialogHeader>
         

--- a/client/src/pages/tasks/TaskDetailsDialog.tsx
+++ b/client/src/pages/tasks/TaskDetailsDialog.tsx
@@ -1,6 +1,6 @@
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
+import { StatusBadge, PriorityBadge } from '@/components/tasks/TaskBadges';
 import { format } from 'date-fns';
 import { useTranslation } from 'react-i18next';
 import { Task } from './useTasks';
@@ -26,32 +26,8 @@ export default function TaskDetailsDialog({ open, onOpenChange, task, onEdit, on
           <div className="flex flex-wrap gap-2 mt-2">
             {task && (
               <>
-                {(() => {
-                  switch (task.priority) {
-                    case 'high':
-                      return <Badge variant="outline" className="bg-red-50 text-red-600 border-red-200">{t('task.priority.high')}</Badge>;
-                    case 'medium':
-                      return <Badge variant="outline" className="bg-orange-50 text-orange-600 border-orange-200">{t('task.priority.medium')}</Badge>;
-                    case 'low':
-                      return <Badge variant="outline" className="bg-green-50 text-green-600 border-green-200">{t('task.priority.low')}</Badge>;
-                    default:
-                      return <Badge variant="outline">{task.priority}</Badge>;
-                  }
-                })()}
-                {(() => {
-                  switch (task.status) {
-                    case 'new':
-                      return <Badge variant="outline" className="bg-blue-50 text-blue-600 border-blue-200">{t('task.status.new')}</Badge>;
-                    case 'in_progress':
-                      return <Badge variant="outline" className="bg-yellow-50 text-yellow-600 border-yellow-200">{t('task.status.in_progress')}</Badge>;
-                    case 'completed':
-                      return <Badge variant="outline" className="bg-green-50 text-green-600 border-green-200">{t('task.status.completed')}</Badge>;
-                    case 'on_hold':
-                      return <Badge variant="outline" className="bg-gray-50 text-gray-600 border-gray-200">{t('task.status.on_hold')}</Badge>;
-                    default:
-                      return <Badge variant="outline">{task.status}</Badge>;
-                  }
-                })()}
+                <PriorityBadge priority={task.priority} />
+                <StatusBadge status={task.status} />
               </>
             )}
           </div>


### PR DESCRIPTION
## Summary
- create `TaskBadges` component with `StatusBadge` and `PriorityBadge`
- reuse the new badge components in `TaskCard`, `TaskDetailsDialog` and `TaskDetailsModal`

## Testing
- `npm run -s check` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_684b02b0db88832083bca7bad6e32b9d