### PR TITLE
Hide inactive pages

### DIFF
--- a/client/src/components/dashboards/NewAdminDashboard.tsx
+++ b/client/src/components/dashboards/NewAdminDashboard.tsx
@@ -354,28 +354,34 @@ const AdminDashboard = () => {
             <CardContent className="p-0">
               <div className="grid grid-cols-2 gap-3 p-3">
                 {/* Files */}
+                {/*
                 <div className="w-full">
                   <Link href="/admin/imported-files" className="rounded-lg border bg-card text-card-foreground shadow-sm hover:bg-accent/10 transition-colors p-4 flex flex-col items-center justify-center gap-2 h-full cursor-pointer">
                     <FileText className="h-8 w-8 text-primary" />
                     <span className="text-sm font-medium">{t('schedule.import.fileManager')}</span>
                   </Link>
                 </div>
+                */}
 
                 {/* Users */}
+                {/*
                 <div className="w-full">
                   <Link href="/users" className="rounded-lg border bg-card text-card-foreground shadow-sm hover:bg-accent/10 transition-colors p-4 flex flex-col items-center justify-center gap-2 h-full cursor-pointer">
                     <Users className="h-8 w-8 text-primary" />
                     <span className="text-sm font-medium">{t('common.users')}</span>
                   </Link>
                 </div>
+                */}
 
                 {/* Requests */}
+                {/*
                 <div className="w-full">
                   <Link href="/requests" className="rounded-lg border bg-card text-card-foreground shadow-sm hover:bg-accent/10 transition-colors p-4 flex flex-col items-center justify-center gap-2 h-full cursor-pointer">
                     <FilePlus className="h-8 w-8 text-primary" />
                     <span className="text-sm font-medium">{t('requests.title')}</span>
                   </Link>
                 </div>
+                */}
 
                 {/* Chat */}
                 <div className="w-full">

--- a/client/src/components/dashboards/StudentDashboard.tsx
+++ b/client/src/components/dashboards/StudentDashboard.tsx
@@ -244,9 +244,11 @@ const StudentDashboard = () => {
                 <CardTitle>{t('dashboard.student.requestHistory', 'История заявок')}</CardTitle>
                 <CardDescription>{t('dashboard.student.latestRequests', 'Последние заявки')}</CardDescription>
               </div>
+              {/*
               <Link href="/requests" className="text-sm font-medium text-primary hover:text-primary-dark">
                 {t('common.actions.view', 'Просмотр')}
               </Link>
+              */}
             </CardHeader>
             <CardContent>
               {requests.length === 0 ? (
@@ -270,11 +272,13 @@ const StudentDashboard = () => {
                         {request.createdAt ? new Date(request.createdAt).toLocaleDateString('ru-RU') : ''}
                       </p>
                       <p className="text-xs text-foreground mt-2 line-clamp-2">{request.description}</p>
+                      {/*
                       <div className="mt-2">
                         <Link href={`/requests/${request.id}`} className="text-xs text-primary hover:underline">
                           {t('common.actions.details', 'Подробнее')}
                         </Link>
                       </div>
+                      */}
                     </div>
                   ))}
                 </div>
@@ -322,19 +326,23 @@ const StudentDashboard = () => {
                   </div>
                 </Link>
                 
+                {/*
                 <Link href="/requests/new">
                   <div className="flex flex-col items-center p-3 bg-muted rounded-lg hover:bg-accent hover:text-accent-foreground transition-all">
                     <FileText className="h-6 w-6 mb-2" />
                     <span className="text-xs font-medium">{t('requests.add', 'Создать заявку')}</span>
                   </div>
                 </Link>
+                */}
                 
+                {/*
                 <Link href="/grades">
                   <div className="flex flex-col items-center p-3 bg-muted rounded-lg hover:bg-accent hover:text-accent-foreground transition-all">
                     <BarChart2 className="h-6 w-6 mb-2" />
                     <span className="text-xs font-medium">{t('grades.title', 'Оценки')}</span>
                   </div>
                 </Link>
+                */}
               </div>
             </CardContent>
           </Card>

--- a/client/src/components/dashboards/TeacherDashboard.tsx
+++ b/client/src/components/dashboards/TeacherDashboard.tsx
@@ -345,22 +345,26 @@ const TeacherDashboard = () => {
                         {t('requests.from', 'От: {{studentId}}', { studentId: request.studentId })}
                       </p>
                       <p className="text-xs mt-2 line-clamp-2">{request.description}</p>
+                      {/*
                       <div className="mt-2">
                         <Link href={`/requests/${request.id}`} className="text-xs text-primary hover:underline">
                           {t('requests.review', 'Рассмотреть заявку')}
                         </Link>
                       </div>
+                      */}
                     </div>
                   ))}
                 </div>
               )}
             </CardContent>
             <CardFooter>
+              {/*
               <Button variant="outline" size="sm" asChild className="w-full">
                 <Link href="/requests">
                   {t('requests.viewAll', 'Просмотреть все заявки')}
                 </Link>
               </Button>
+              */}
             </CardFooter>
           </Card>
           
@@ -378,12 +382,14 @@ const TeacherDashboard = () => {
                   </div>
                 </Link>
                 
+                {/*
                 <Link href="/grades">
                   <div className="flex flex-col items-center p-3 bg-muted rounded-lg hover:bg-accent hover:text-accent-foreground transition-all">
                     <BarChart2 className="h-6 w-6 mb-2" />
                     <span className="text-xs font-medium text-center">{t('grades.title', 'Оценки')}</span>
                   </div>
                 </Link>
+                */}
                 
                 <Link href="/chat">
                   <div className="flex flex-col items-center p-3 bg-muted rounded-lg hover:bg-accent hover:text-accent-foreground transition-all">

--- a/client/src/components/layout/navbar.tsx
+++ b/client/src/components/layout/navbar.tsx
@@ -30,9 +30,9 @@ const navigationItems = [
   { key: "dashboard.title", href: "/", icon: BookOpen },
   { key: "schedule.title", href: "/schedule", icon: Calendar },
   { key: "assignments.title", href: "/assignments", icon: FileText },
-  { key: "grades.title", href: "/grades", icon: Award },
+  // { key: "grades.title", href: "/grades", icon: Award },
   { key: "chat.title", href: "/chat", icon: MessageSquare },
-  { key: "users.title", href: "/users", icon: Users, adminOnly: true },
+  // { key: "users.title", href: "/users", icon: Users, adminOnly: true },
 ];
 
 export function Navbar() {

--- a/client/src/components/layout/sidebar.tsx
+++ b/client/src/components/layout/sidebar.tsx
@@ -27,12 +27,12 @@ const navigationItems = [
   { key: "dashboard.title", href: "/", icon: LayoutDashboard },
   { key: "schedule.title", href: "/schedule", icon: Calendar },
   { key: "assignments.title", href: "/assignments", icon: FileText },
-  { key: "grades.title", href: "/grades", icon: Award },
+  // { key: "grades.title", href: "/grades", icon: Award },
   { key: "chat.title", href: "/chat", icon: MessageSquare },
   { key: "common.taskManager", href: "/tasks", icon: ClipboardList },
-  { key: "users.title", href: "/users", icon: Users, adminOnly: true },
-  { key: "schedule.import.fileManager", href: "/admin/imported-files", icon: FileManagerIcon, adminOnly: true },
-  { key: "curriculum.title", href: "/curriculum-plans", icon: FileText, adminOnly: true },
+  // { key: "users.title", href: "/users", icon: Users, adminOnly: true },
+  // { key: "schedule.import.fileManager", href: "/admin/imported-files", icon: FileManagerIcon, adminOnly: true },
+  // { key: "curriculum.title", href: "/curriculum-plans", icon: FileText, adminOnly: true },
   { key: "settings.title", href: "/settings", icon: Settings },
 ];
 


### PR DESCRIPTION
## Summary
- hide disabled routes from the sidebar and top navbar
- comment quick links on dashboards that lead to disabled pages
- keep admin routing commented out

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_68513e91accc8320a892d3e581f2d1b5