### PR TITLE
Enable user management routes

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -10,6 +10,8 @@ import NotFound from "@/pages/not-found";
 import AuthPage from "@/pages/auth-page";
 import { ProtectedRoute } from "@/lib/protected-route";
 import { useAuth } from "@/hooks/use-auth";
+import Users from "@/pages/users/Users";
+import UserDetail from "@/pages/users/UserDetail";
 
 import { MainLayout } from "@/components/layout/main-layout";
 // import StudentExample from "@/components/students/StudentExample";
@@ -45,11 +47,11 @@ const ProtectedSchedule = () => (
 //   </MainLayout>
 // );
 
-// const ProtectedUsers = () => (
-//   <MainLayout>
-//     <Users />
-//   </MainLayout>
-// );
+const ProtectedUsers = () => (
+  <MainLayout>
+    <Users />
+  </MainLayout>
+);
 
 // const ProtectedRequests = () => (
 //   <MainLayout>
@@ -111,12 +113,11 @@ const ProtectedTasks = () => (
 // );
 
 // User detail page
-// import UserDetail from "@/pages/users/UserDetail";
-// const ProtectedUserDetail = () => (
-//   <MainLayout>
-//     <UserDetail />
-//   </MainLayout>
-// );
+const ProtectedUserDetail = () => (
+  <MainLayout>
+    <UserDetail />
+  </MainLayout>
+);
 
 // Student Example component for testing
 // const ProtectedStudentExample = () => (
@@ -153,8 +154,8 @@ function App() {
       {/** <ProtectedRoute path="/grades" component={ProtectedGrades} /> **/}
 
       {/* User management routes (admin only) */}
-      {/** <ProtectedRoute path="/users" component={ProtectedUsers} adminOnly={true} /> **/}
-      {/** <ProtectedRoute path="/users/:id" component={ProtectedUserDetail} adminOnly={true} /> **/}
+      <ProtectedRoute path="/users" component={ProtectedUsers} adminOnly={true} />
+      <ProtectedRoute path="/users/:id" component={ProtectedUserDetail} adminOnly={true} />
 
       {/* Requests route */}
       {/** <ProtectedRoute path="/requests" component={ProtectedRequests} /> **/}

--- a/client/src/components/layout/navbar.tsx
+++ b/client/src/components/layout/navbar.tsx
@@ -32,7 +32,7 @@ const navigationItems = [
   { key: "assignments.title", href: "/assignments", icon: FileText },
   // { key: "grades.title", href: "/grades", icon: Award },
   { key: "chat.title", href: "/chat", icon: MessageSquare },
-  // { key: "users.title", href: "/users", icon: Users, adminOnly: true },
+  { key: "users.title", href: "/users", icon: Users, adminOnly: true },
 ];
 
 export function Navbar() {

--- a/client/src/components/layout/sidebar.tsx
+++ b/client/src/components/layout/sidebar.tsx
@@ -30,7 +30,7 @@ const navigationItems = [
   // { key: "grades.title", href: "/grades", icon: Award },
   { key: "chat.title", href: "/chat", icon: MessageSquare },
   { key: "common.taskManager", href: "/tasks", icon: ClipboardList },
-  // { key: "users.title", href: "/users", icon: Users, adminOnly: true },
+  { key: "users.title", href: "/users", icon: Users, adminOnly: true },
   // { key: "schedule.import.fileManager", href: "/admin/imported-files", icon: FileManagerIcon, adminOnly: true },
   // { key: "curriculum.title", href: "/curriculum-plans", icon: FileText, adminOnly: true },
   { key: "settings.title", href: "/settings", icon: Settings },


### PR DESCRIPTION
## Summary
- expose Users link in sidebar and navbar
- wire up Users pages and routes

## Testing
- `npm run check`
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_68527d6ad6808320bd1d7d294ff5c9c0