### PR TITLE
Fix unclickable create button in task dialog

### DIFF
--- a/client/src/pages/tasks/CreateTaskDialog.tsx
+++ b/client/src/pages/tasks/CreateTaskDialog.tsx
@@ -91,6 +91,11 @@ export default function CreateTaskDialog({ open, onOpenChange, form, onSubmit, l
                 label: `${u.firstName} ${u.lastName} (${t(`role.${u.role}`)})`,
               }))}
             />
+            {!users || users.length === 0 ? (
+              <p className="text-sm text-muted-foreground">
+                {t('task.no_users_available')}
+              </p>
+            ) : null}
             <FormField
               control={form.control}
               name="dueDate"
@@ -124,7 +129,12 @@ export default function CreateTaskDialog({ open, onOpenChange, form, onSubmit, l
               )}
             />
             <DialogFooter>
-              <Button type="submit" disabled={loading}>{t('task.create')}</Button>
+              <Button
+                type="submit"
+                disabled={loading || !users || users.length === 0}
+              >
+                {t('task.create')}
+              </Button>
             </DialogFooter>
           </form>
         </Form>


### PR DESCRIPTION
## Summary
- show a message when executor list is empty
- disable the create button when no executors available

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_68527dfbe07c8320836ab10606833fea