### PR TITLE
Refactor server auth to use Supabase

### DIFF
--- a/server/supabaseClient.ts
+++ b/server/supabaseClient.ts
@@ -1,0 +1,10 @@
+import { createClient } from '@supabase/supabase-js';
+
+const SUPABASE_URL = process.env.SUPABASE_URL;
+const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
+  throw new Error('SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY must be provided');
+}
+
+export const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);


### PR DESCRIPTION
## Summary
- drop passport and sessions from server auth setup
- add Supabase auth client
- reimplement login/register/logout handlers

## Testing
- `npm run check`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6852fa56eadc8320a8c4d4b9b5563f5e