### PR TITLE
Implement JWT auth middleware

### DIFF
--- a/server/middleware/verifySupabaseJwt.ts
+++ b/server/middleware/verifySupabaseJwt.ts
@@ -1,0 +1,42 @@
+import { Request, Response, NextFunction } from 'express';
+import { createClient } from '@supabase/supabase-js';
+
+const SUPABASE_URL = process.env.SUPABASE_URL || '';
+const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_ANON_KEY || '';
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+
+export async function verifySupabaseJwt(req: Request, res: Response, next: NextFunction) {
+  try {
+    let token: string | undefined;
+
+    const authHeader = req.headers.authorization;
+    if (authHeader?.startsWith('Bearer ')) {
+      token = authHeader.slice(7);
+    }
+
+    if (!token && req.headers.cookie) {
+      const cookies = req.headers.cookie.split(';').map(c => c.trim());
+      for (const cookie of cookies) {
+        if (cookie.startsWith('sb-access-token=')) {
+          token = cookie.substring('sb-access-token='.length);
+          break;
+        }
+      }
+    }
+
+    if (!token) {
+      return res.status(401).json({ message: 'Unauthorized' });
+    }
+
+    const { data, error } = await supabase.auth.getUser(token);
+    if (error || !data?.user) {
+      return res.status(401).json({ message: 'Unauthorized' });
+    }
+
+    (req as any).user = data.user;
+    next();
+  } catch (err) {
+    next(err);
+  }
+}


### PR DESCRIPTION
## Summary
- verify Supabase JWT tokens via new middleware
- use the middleware for route authentication
- remove session logic from routes

## Testing
- `npm run check`
- `npm install @supabase/supabase-js@latest` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6852fa711ed08320bc0b2fde1a60b3f9