### PR TITLE
Remove leftover session store code

### DIFF
--- a/server/db/storage.ts
+++ b/server/db/storage.ts
@@ -6,10 +6,7 @@ import { IStorage } from '../storage';
 import { UsersRepository } from './users/repository';
 import { SubjectsRepository } from './subjects/repository';
 import { TasksRepository } from './tasks/repository';
-import session from 'express-session';
-import createMemoryStore from 'memorystore';
 import pg from 'pg';
-import connectPgSimple from 'connect-pg-simple';
 import { getOrSet } from '../utils/cache';
 
 import * as notificationQueries from './notifications';
@@ -31,27 +28,17 @@ import { log } from '../vite';
 
 type EducationLevel = (typeof schema.educationLevelEnum.enumValues)[number];
 
-const MemoryStore = createMemoryStore(session);
-const PgSession = connectPgSimple(session);
 
 /**
  * Реализация IStorage, использующая базу данных Supabase
  */
 export class SupabaseStorage {
-  sessionStore: session.Store;
   private usersRepo = new UsersRepository();
   private subjectsRepo = new SubjectsRepository();
   private tasksRepo = new TasksRepository();
 
   constructor() {
-    // Use MemoryStore for session storage for better reliability in Replit environment
-    // This is simpler but will lose sessions on server restart
-    this.sessionStore = new MemoryStore({
-      checkPeriod: 86400000, // Prune expired entries every 24h
-      stale: false, // Don't allow stale sessions
-    });
-    
-    log("Using in-memory session storage for better reliability");
+    log("Using in-memory storage for better reliability");
   }
 
   // User management

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -20,18 +20,12 @@ import {
 } from "@shared/schema";
 import { eq, and, desc, asc } from "drizzle-orm";
 import { db } from "./db";
-import session from "express-session";
-import * as expressSession from 'express-session';
-import createMemoryStore from "memorystore";
-import PgStoreFactory from 'connect-pg-simple';
+
 import { logger } from "./utils/logger";
 import { getOrSet } from "./utils/cache";
 
-const MemoryStore = createMemoryStore(session);
-
 // Storage interface
 export interface IStorage {
-  sessionStore: expressSession.Store;
   // User management
   getUsers(): Promise<User[]>;
   getUser(id: number): Promise<User | undefined>;
@@ -261,8 +255,6 @@ export class MemStorage implements IStorage {
   private taskIdCounter: number;
   private curriculumPlanIdCounter: number;
   
-  sessionStore: expressSession.Store;
-  
   constructor() {
     this.users = new Map();
     this.subjects = new Map();
@@ -307,14 +299,6 @@ export class MemStorage implements IStorage {
     this.activityLogIdCounter = 1;
     this.taskIdCounter = 1;
     this.curriculumPlanIdCounter = 1;
-    
-    // Настройка MemoryStore для длительного хранения сессий
-    this.sessionStore = new MemoryStore({
-      checkPeriod: 86400000, // проверка и удаление устаревших сессий каждые 24ч
-      max: 5000, // максимальное количество сессий в памяти
-      ttl: 14 * 24 * 60 * 60 * 1000, // время жизни сессии - 14 дней
-      stale: false // не возвращать просроченные объекты
-    });
     
     // Add some seed data
     this.seedData();


### PR DESCRIPTION
## Summary
- remove `sessionStore` from storage interface and memory/db implementations
- drop unused session store imports

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6852ff62630c8320ad85784e5ccdec7a