### PR TITLE
Fix auth token header for user requests

### DIFF
--- a/client/src/hooks/use-auth.tsx
+++ b/client/src/hooks/use-auth.tsx
@@ -96,6 +96,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           cache: 'no-store'
         };
 
+        const token = sessionData.session?.access_token;
+        if (token) {
+          (fetchOptions.headers as Record<string, string>)["Authorization"] = `Bearer ${token}`;
+        }
+
         devLog('Fetch /api/user', {
           method: fetchOptions.method,
           url: '/api/user',
@@ -143,7 +148,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         method: 'GET',
         credentials: 'include',
         cache: 'no-store',
+        headers: {}
       };
+
+      const token = sessionData.session?.access_token;
+      if (token) {
+        (fetchOptions.headers as Record<string, string>)["Authorization"] = `Bearer ${token}`;
+      }
 
       devLog('Fetch /api/user', {
         method: fetchOptions.method,
@@ -190,7 +201,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         method: 'GET',
         credentials: 'include',
         cache: 'no-store',
+        headers: {}
       };
+
+      const token = sessionData.session?.access_token;
+      if (token) {
+        (fetchOptions.headers as Record<string, string>)["Authorization"] = `Bearer ${token}`;
+      }
 
       devLog('Fetch /api/user', {
         method: fetchOptions.method,


### PR DESCRIPTION
## Summary
- include the Supabase session token in `Authorization` header when requesting `/api/user`
- send the token after login and registration

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6853e40425b88320bb1ec4dc2ed59b11