### PR TITLE
Fix auth header for query client

### DIFF
--- a/client/src/components/schedule/ScheduleImport.tsx
+++ b/client/src/components/schedule/ScheduleImport.tsx
@@ -6,6 +6,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { authFetch } from '@/lib/queryClient';
 import { useToast } from '@/hooks/use-toast';
 import { useForm } from 'react-hook-form';
 import { apiRequest } from '@/lib/queryClient';
@@ -123,10 +124,9 @@ export default function ScheduleImport() {
       const formData = new FormData();
       formData.append('csvFile', selectedFile);
 
-      const response = await fetch('/api/schedule/import/csv', {
+      const response = await authFetch('/api/schedule/import/csv', {
         method: 'POST',
         body: formData,
-        credentials: 'include'
       });
 
       if (!response.ok) {

--- a/client/src/hooks/use-auth.tsx
+++ b/client/src/hooks/use-auth.tsx
@@ -7,11 +7,8 @@ import {
 } from "@tanstack/react-query";
 import { User } from "@shared/schema";
 import { useToast } from "@/hooks/use-toast";
-import { createClient } from '@supabase/supabase-js';
-
-const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL as string;
-const SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY as string;
-const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+import { supabase } from '@/lib/supabase';
+import { authFetch } from '@/lib/queryClient';
 
 // Development only logger
 const devLog = (...args: unknown[]) => {
@@ -108,7 +105,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           headers: fetchOptions.headers,
         });
 
-        const res = await fetch("/api/user", fetchOptions);
+        const res = await authFetch("/api/user", fetchOptions);
         
         if (res.status === 401) {
           // Если получили 401, очищаем localStorage
@@ -163,7 +160,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         headers: fetchOptions.headers,
       });
 
-      const res = await fetch("/api/user", fetchOptions);
+      const res = await authFetch("/api/user", fetchOptions);
       if (!res.ok) {
         throw new Error('Failed to fetch user data');
       }
@@ -216,7 +213,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         headers: fetchOptions.headers,
       });
 
-      const res = await fetch('/api/user', fetchOptions);
+      const res = await authFetch('/api/user', fetchOptions);
       if (!res.ok) {
         throw new Error('Failed to fetch user data');
       }

--- a/client/src/hooks/useAutoSave.ts
+++ b/client/src/hooks/useAutoSave.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
 import { useToast } from '@/hooks/use-toast';
+import { authFetch } from '@/lib/queryClient';
 import stableStringify from 'fast-json-stable-stringify';
 
 interface AutoSaveOptions {
@@ -129,13 +130,12 @@ export function useAutoSave<T>(data: T, options: AutoSaveOptions) {
     
     try {
       
-      const response = await fetch(url, {
+      const response = await authFetch(url, {
         method,
         headers: {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify(dataToSave),
-        credentials: 'include',
       });
       
       if (!response.ok) {

--- a/client/src/hooks/useFilteredSchedule.ts
+++ b/client/src/hooks/useFilteredSchedule.ts
@@ -4,6 +4,7 @@ import { format, startOfWeek, endOfWeek, startOfMonth, endOfMonth, startOfYear, 
 import { ru } from 'date-fns/locale';
 import { useAuth } from '@/hooks/use-auth';
 import { isAdmin } from '@/lib/auth';
+import { authFetch } from '@/lib/queryClient';
 
 const DAYS_OF_WEEK = ['Воскресенье', 'Понедельник', 'Вторник', 'Среда', 'Четверг', 'Пятница', 'Суббота'];
 
@@ -20,7 +21,7 @@ export function useFilteredSchedule() {
   const allSchedule = useQuery({
     queryKey: ['/api/schedule'],
     queryFn: async () => {
-      const response = await fetch('/api/schedule', { credentials: 'include' });
+      const response = await authFetch('/api/schedule');
       if (!response.ok) {
         throw new Error('Не удалось загрузить полное расписание');
       }
@@ -33,7 +34,7 @@ export function useFilteredSchedule() {
     queryKey: [isStudent ? '/api/schedule/student' : '/api/schedule/teacher'],
     queryFn: async () => {
       const endpoint = isStudent ? '/api/schedule/student' : '/api/schedule/teacher';
-      const response = await fetch(endpoint, { credentials: 'include' });
+      const response = await authFetch(endpoint);
       if (!response.ok) {
         throw new Error('Не удалось загрузить расписание');
       }

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -1,4 +1,4 @@
-import { apiRequest } from "./queryClient";
+import { apiRequest, authFetch } from "./queryClient";
 import { getAuthHeaders } from "./auth";
 
 // Generic fetch function for GET requests with improved Safari compatibility
@@ -8,7 +8,7 @@ export async function fetchData<T>(endpoint: string): Promise<T> {
   const timeoutId = setTimeout(() => controller.abort(), 30000);
   
   try {
-    const response = await fetch(endpoint, {
+    const response = await authFetch(endpoint, {
       method: 'GET', // Явно указываем метод
       headers: {
         ...getAuthHeaders(),
@@ -18,7 +18,6 @@ export async function fetchData<T>(endpoint: string): Promise<T> {
         'Pragma': 'no-cache',
         'Expires': '0'
       },
-      credentials: 'include', // Всегда включаем куки
       mode: 'cors', // Для лучшей совместимости
       redirect: 'follow', // Следуем за перенаправлениями
       signal: controller.signal // Для тайм-аута
@@ -86,7 +85,7 @@ export async function uploadFile(endpoint: string, formData: FormData): Promise<
       delete formHeaders['Content-Type'];
     }
     
-    const response = await fetch(endpoint, {
+    const response = await authFetch(endpoint, {
       method: 'POST',
       headers: {
         ...formHeaders,
@@ -96,7 +95,6 @@ export async function uploadFile(endpoint: string, formData: FormData): Promise<
         'Pragma': 'no-cache'
       },
       body: formData,
-      credentials: 'include',
       mode: 'cors',
       redirect: 'follow',
       signal: controller.signal // Для тайм-аута

--- a/client/src/lib/supabase.ts
+++ b/client/src/lib/supabase.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js';
+
+const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL as string;
+const SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY as string;
+
+export const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);

--- a/client/src/pages/assignments/useAssignments.ts
+++ b/client/src/pages/assignments/useAssignments.ts
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useAuth } from '@/hooks/use-auth';
 import { useToast } from '@/hooks/use-toast';
-import { queryClient as globalClient } from '@/lib/queryClient';
+import { queryClient as globalClient, authFetch } from '@/lib/queryClient';
 import * as z from 'zod';
 
 export const createAssignmentSchema = z.object({
@@ -29,7 +29,7 @@ export function useAssignments() {
     queryKey: [isStudent ? '/api/assignments/student' : '/api/assignments/teacher'],
     queryFn: async () => {
       const endpoint = isStudent ? '/api/assignments/student' : '/api/assignments/teacher';
-      const response = await fetch(endpoint);
+      const response = await authFetch(endpoint);
       if (!response.ok) throw new Error('Failed to fetch assignments');
       return await response.json();
     },
@@ -39,7 +39,7 @@ export function useAssignments() {
   const { data: subjects } = useQuery({
     queryKey: [`/api/subjects/teacher/${user?.id}`],
     queryFn: async () => {
-      const response = await fetch(`/api/subjects/teacher/${user!.id}`);
+      const response = await authFetch(`/api/subjects/teacher/${user!.id}`);
       if (!response.ok) throw new Error('Failed to fetch subjects');
       return await response.json();
     },
@@ -48,7 +48,7 @@ export function useAssignments() {
 
   const createAssignmentMutation = useMutation({
     mutationFn: async (data: z.infer<typeof createAssignmentSchema>) => {
-      const response = await fetch('/api/assignments', {
+      const response = await authFetch('/api/assignments', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ ...data, teacherId: user!.id }),
@@ -70,7 +70,7 @@ export function useAssignments() {
 
   const submitAssignmentMutation = useMutation({
     mutationFn: async (data: z.infer<typeof submitAssignmentSchema> & { assignmentId: number }) => {
-      const response = await fetch('/api/submissions', {
+      const response = await authFetch('/api/submissions', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ ...data, studentId: user!.id }),


### PR DESCRIPTION
## Summary
- add Supabase client instance
- create authFetch helper that injects `Authorization`
- refactor API helpers and hooks to use authFetch

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6853e5d1e4a48320b8590173e22051bc