### PR TITLE
Fix env var name in debug server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,13 @@
 # Supabase / PostgreSQL connection string
 SUPABASE_DATABASE_URL=postgresql://USER:PASSWORD@HOST:5432/DATABASE
 
+# Supabase project details
+SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_ANON_KEY=public-anon-key
+SUPABASE_SERVICE_ROLE_KEY=service-role-key
+VITE_SUPABASE_URL=https://your-project.supabase.co
+VITE_SUPABASE_ANON_KEY=public-anon-key
+
 # Optional: same URL used by Drizzle
 DATABASE_URL=
 

--- a/debug-server.js
+++ b/debug-server.js
@@ -10,7 +10,7 @@ app.post('/test/create-task', async (req, res) => {
     const { createClient } = await import('@supabase/supabase-js')
     const supabase = createClient(
       process.env.SUPABASE_URL,
-      process.env.SUPABASE_SERVICE_KEY // service key для обхода RLS
+      process.env.SUPABASE_SERVICE_ROLE_KEY // service key для обхода RLS
     )
 
     console.log('🚀 Попытка создать задачу...')
@@ -50,7 +50,7 @@ app.get('/test/tasks', async (req, res) => {
     const { createClient } = await import('@supabase/supabase-js')
     const supabase = createClient(
       process.env.SUPABASE_URL,
-      process.env.SUPABASE_SERVICE_KEY
+      process.env.SUPABASE_SERVICE_ROLE_KEY
     )
 
     const { data, error } = await supabase


### PR DESCRIPTION
## Summary
- use `SUPABASE_SERVICE_ROLE_KEY` when creating clients in `debug-server.js`
- add Supabase project variables to `.env.example`

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6853ecbd50f08320abf63e4aaf301942