### PR TITLE
Remove legacy storage export

### DIFF
--- a/server/auth.ts
+++ b/server/auth.ts
@@ -5,8 +5,8 @@ import { supabase } from "./supabaseClient";
 import { verifySupabaseJwt } from "./middleware/verifySupabaseJwt";
 import { logger } from "./utils/logger";
 
-// Import storage module and IStorage interface
-import { storage, IStorage, setStorage, getStorage, DatabaseStorage } from "./storage";
+// Import storage helpers and interface
+import { IStorage, setStorage, getStorage, DatabaseStorage } from "./storage";
 
 declare global {
   namespace Express {

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1684,5 +1684,3 @@ export const setStorage = (newStorage: IStorage): void => {
   logger.info('Storage implementation has been updated');
 };
 
-// Для обратной совместимости экспортируем ссылку на хранилище
-export const storage = _storage;


### PR DESCRIPTION
## Summary
- drop `storage` export in server module
- use `getStorage()` instead of importing `storage`

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6853f3797b488320b402d1a5a881b6e1