### PR TITLE
Fix toast parameter typing

### DIFF
--- a/client/src/hooks/use-toast.ts
+++ b/client/src/hooks/use-toast.ts
@@ -139,7 +139,7 @@ function dispatch(action: Action) {
 
 type Toast = Omit<ToasterToast, "id">
 
-function toast({ ...props }: Toast) {
+function toast(props: Toast) {
   const id = genId()
 
   const update = (props: ToasterToast) =>


### PR DESCRIPTION
## Summary
- fix rest object usage in `use-toast`

## Testing
- `npx tsc --noEmit` *(fails: No overload matches call)*

------
https://chatgpt.com/codex/tasks/task_e_685406849fa08320ab8322f7b357bbe6