### PR TITLE
Fix TypeScript rest parameter error

### DIFF
--- a/client/src/hooks/use-auth.tsx
+++ b/client/src/hooks/use-auth.tsx
@@ -12,7 +12,8 @@ import { authFetch } from '@/lib/queryClient';
 import { logger } from '@/lib/logger';
 
 // Development only logger
-const devLog = (...args: unknown[]) => {
+// Expect at least one argument to satisfy TypeScript's tuple requirement
+const devLog = (...args: [unknown, ...unknown[]]) => {
   if (import.meta.env.DEV) {
     logger.info(...args);
   }


### PR DESCRIPTION
## Summary
- address TypeScript 5.6 tuple requirement for spread arguments in `use-auth`

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_6854092bedbc832094da1d06ce88a65c