### PR TITLE
Add dev proxy configuration

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -36,7 +36,10 @@ export default defineConfig({
     open: true,
     proxy: {
       // Прокидываем API-запросы на бэкенд
-      '/api': 'http://localhost:5050',
+      '/api': {
+        target: 'http://localhost:5050',
+        changeOrigin: true,
+      },
       // Можно добавить любые другие эндпоинты
     },
   },


### PR DESCRIPTION
## Summary
- add proxy configuration so `/api` requests hit the backend running on port 5050

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_685413aa44308320bf3c3e2513bb58e8