### PR TITLE
Fix Supabase storage log line

### DIFF
--- a/server/db/storage.ts
+++ b/server/db/storage.ts
@@ -39,7 +39,7 @@ export class SupabaseStorage {
   private tasksRepo = new TasksRepository();
 
   constructor() {
-    log("Using in-memory storage for better reliability");
+    log("Using Supabase storage");
   }
 
   // User management


### PR DESCRIPTION
## Summary
- fix misleading log message in `SupabaseStorage` constructor

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_685416398f588320bde1a203e0bc6c88