### PR TITLE
Refactor database init flow

### DIFF
--- a/server/auth.ts
+++ b/server/auth.ts
@@ -4,6 +4,7 @@ import { User as SelectUser } from "../shared/schema";
 import { supabase } from "./supabaseClient";
 import { verifySupabaseJwt } from "./middleware/verifySupabaseJwt";
 import { logger } from "./utils/logger";
+import { testConnection } from "./db";
 
 // Import storage helpers and interface
 import { IStorage, setStorage, getStorage, DatabaseStorage } from "./storage";
@@ -42,6 +43,13 @@ export async function initializeDatabase(): Promise<boolean> {
   try {
     logger.info("Starting database migration...");
     try {
+      // Проверяем соединение с базой данных
+      const isConnected = await testConnection();
+      if (!isConnected) {
+        logger.error("Failed to connect to the database");
+        return false;
+      }
+
       // Создаем хранилище базы данных Supabase
       logger.info("Creating SupabaseStorage instance...");
       const dbStorage = new DatabaseStorage();

--- a/server/index.ts
+++ b/server/index.ts
@@ -3,7 +3,6 @@ import express, { type Request, Response, NextFunction } from "express";
 import { registerRoutes } from "./routes";
 import { setupVite, serveStatic, log } from "./vite";
 import { initializeDatabase } from "./auth";
-import { setStorage, DatabaseStorage, type IStorage } from "./storage";
 
 const app = express();
 app.use(express.json());
@@ -63,23 +62,9 @@ app.use((req, res, next) => {
     // Initialize the database before setting up routes
     log("Initializing database...");
 
-    try {
-      // Попробуем инициализировать SupabaseStorage сразу
-      const dbStorage = new DatabaseStorage();
-      setStorage(dbStorage as unknown as IStorage);
-      log("Database connection successful");
-      log("Using in-memory session storage for better reliability");
-      log("Storage implementation has been updated");
-      log("Successfully initialized database storage");
-      log("Database initialized successfully");
-    } catch (error) {
-      log("Error initializing database storage:", error instanceof Error ? error.message : String(error));
-      log("Warning: Database initialization failed, falling back to in-memory storage");
-      // Fallback на initializeDatabase(), который использует MemStorage
-      const dbInitialized = await initializeDatabase();
-      if (!dbInitialized) {
-        log("Warning: Both database options failed, continuing with in-memory storage");
-      }
+    const dbInitialized = await initializeDatabase();
+    if (!dbInitialized) {
+      log("Warning: Database initialization failed, continuing with in-memory storage");
     }
 
     // Register API routes


### PR DESCRIPTION
## Summary
- remove local DatabaseStorage initialization from server startup
- rely on `initializeDatabase` for connection and seeding
- check database connectivity inside `initializeDatabase`

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6854163b82f88320b94c65bb7a7dedc5