### PR TITLE
Refactor DB initialization fallback

### DIFF
--- a/server/db/storage.ts
+++ b/server/db/storage.ts
@@ -20,7 +20,6 @@ import {
   LoginCredentials, ImportedFile, InsertImportedFile, ActivityLog, InsertActivityLog,
   Task, InsertTask, UserSummary
 } from '@shared/schema';
-import { testConnection } from './index';
 import bcrypt from 'bcrypt';
 import fs from 'fs';
 import path from 'path';
@@ -913,13 +912,6 @@ export class SupabaseStorage {
 
 // Factory function to create a database-backed storage
 export async function createDatabaseStorage(): Promise<IStorage> {
-  // Test database connection
-  const isConnected = await testConnection();
-  
-  if (!isConnected) {
-    console.error('Failed to connect to the database. Using in-memory storage instead.');
-    throw new Error('Database connection failed');
-  }
-  
+  // Simply create Supabase storage instance
   return new SupabaseStorage() as unknown as IStorage;
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -3,7 +3,6 @@ import express, { type Request, Response, NextFunction } from "express";
 import { registerRoutes } from "./routes";
 import { setupVite, serveStatic, log } from "./vite";
 import { initializeDatabase } from "./auth";
-import { setStorage, DatabaseStorage, type IStorage } from "./storage";
 
 const app = express();
 app.use(express.json());
@@ -63,23 +62,11 @@ app.use((req, res, next) => {
     // Initialize the database before setting up routes
     log("Initializing database...");
 
-    try {
-      // Попробуем инициализировать SupabaseStorage сразу
-      const dbStorage = new DatabaseStorage();
-      setStorage(dbStorage as unknown as IStorage);
-      log("Database connection successful");
-      log("Using in-memory session storage for better reliability");
-      log("Storage implementation has been updated");
-      log("Successfully initialized database storage");
+    const dbInitialized = await initializeDatabase();
+    if (dbInitialized) {
       log("Database initialized successfully");
-    } catch (error) {
-      log("Error initializing database storage:", error instanceof Error ? error.message : String(error));
-      log("Warning: Database initialization failed, falling back to in-memory storage");
-      // Fallback на initializeDatabase(), который использует MemStorage
-      const dbInitialized = await initializeDatabase();
-      if (!dbInitialized) {
-        log("Warning: Both database options failed, continuing with in-memory storage");
-      }
+    } else {
+      log("Warning: Database initialization failed, using in-memory storage");
     }
 
     // Register API routes


### PR DESCRIPTION
## Summary
- move connection test into `initializeDatabase`
- simplify `createDatabaseStorage`
- use single initialization path in `server/index`

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6854163c105c8320b8eba60e2c902ffa