### PR TITLE
Fix registration options for signUp

### DIFF
--- a/client/src/hooks/use-auth.tsx
+++ b/client/src/hooks/use-auth.tsx
@@ -189,7 +189,17 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const registerMutation = useMutation({
     mutationFn: async (userData: RegisterData) => {
       const { email, password } = userData;
-      const { error } = await supabase.auth.signUp({ email, password });
+      const { error } = await supabase.auth.signUp({
+        email,
+        password,
+        options: {
+          data: {
+            first_name: userData.firstName,
+            last_name: userData.lastName,
+            role: userData.role
+          }
+        }
+      });
       if (error) {
         throw new Error(error.message);
       }


### PR DESCRIPTION
## Summary
- send additional user metadata when registering so first name, last name and role are stored

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68551bb98b7083209abc173300fb2ee5