### PR TITLE
Fix port mismatch and add health check

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,4 +88,4 @@ npm run dev:client
 
 The server will automatically use `SupabaseStorage` for all data access.
 
-Note: The API is available at http://localhost:5050.
+Note: The API is available at http://localhost:5000.

--- a/server/index.ts
+++ b/server/index.ts
@@ -57,6 +57,10 @@ app.use((req, res, next) => {
   next();
 });
 
+app.get("/api/health", (req, res) => {
+  res.json({ status: "ok", port: 5000, timestamp: new Date() });
+});
+
 (async () => {
   try {
     // Initialize the database before setting up routes
@@ -86,7 +90,7 @@ app.use((req, res, next) => {
     // ALWAYS serve the app on port 5000
     // this serves both the API and the client.
     // It is the only port that is not firewalled.
-    const port = 5050;
+    const port = 5000;
     server.listen({
       port,
       host: "0.0.0.0",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -37,7 +37,7 @@ export default defineConfig({
     proxy: {
       // Прокидываем API-запросы на бэкенд
       '/api': {
-        target: 'http://localhost:5050',
+        target: 'http://localhost:5000',
         changeOrigin: true,
       },
       // Можно добавить любые другие эндпоинты


### PR DESCRIPTION
## Summary
- align server port with docs (5000)
- update development proxy for API
- document new port in README
- add `/api/health` endpoint for monitoring

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6855454082f48320a7d556d968855b1d