### PR TITLE
Change server port to 3001

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,4 +88,4 @@ npm run dev:client
 
 The server will automatically use `SupabaseStorage` for all data access.
 
-Note: The API is available at http://localhost:5000.
+Note: The API is available at http://localhost:3001.

--- a/server/index.ts
+++ b/server/index.ts
@@ -57,8 +57,9 @@ app.use((req, res, next) => {
   next();
 });
 
-app.get("/api/health", (req, res) => {
-  res.json({ status: "ok", port: 5000, timestamp: new Date() });
+// health check endpoint used by deployment scripts
+app.get("/api/health", (_req, res) => {
+  res.json({ status: "ok", port: 3001, timestamp: new Date() });
 });
 
 (async () => {
@@ -87,10 +88,10 @@ app.get("/api/health", (req, res) => {
       serveStatic(app);
     }
 
-    // ALWAYS serve the app on port 5000
-    // this serves both the API and the client.
-    // It is the only port that is not firewalled.
-    const port = 5000;
+  // ALWAYS serve the app on port 3001
+  // this serves both the API and the client.
+  // It avoids conflicts with macOS ControlCenter
+  const port = 3001;
     server.listen({
       port,
       host: "0.0.0.0",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -37,7 +37,7 @@ export default defineConfig({
     proxy: {
       // Прокидываем API-запросы на бэкенд
       '/api': {
-        target: 'http://localhost:5000',
+        target: 'http://localhost:3001',
         changeOrigin: true,
       },
       // Можно добавить любые другие эндпоинты


### PR DESCRIPTION
## Summary
- update server to listen on port 3001
- change proxy target to `localhost:3001`
- document new port in README
- add health endpoint comment and update response

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_685549715ce883208a3681a98e466999