### PR TITLE
Add requests endpoint

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -2,7 +2,8 @@ import 'dotenv/config';
 import express, { type Request, Response, NextFunction } from "express";
 import { registerRoutes } from "./routes";
 import { setupVite, serveStatic, log } from "./vite";
-import { initializeDatabase } from "./auth";
+import { initializeDatabase, authRoutes } from "./auth";
+import { verifySupabaseJwt } from "./middleware/verifySupabaseJwt";
 
 const app = express();
 app.use(express.json());
@@ -61,6 +62,9 @@ app.use((req, res, next) => {
 app.get("/api/health", (_req, res) => {
   res.json({ status: "ok", port: 3001, timestamp: new Date() });
 });
+
+// Requests endpoint used by the front-end
+app.get('/api/requests', verifySupabaseJwt, authRoutes.getRequests);
 
 (async () => {
   try {

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -218,30 +218,6 @@ export async function registerRoutes(app: Express): Promise<Server> {
   // registerCurriculumRoutes(app, ctx);
 
   // Lightweight Supabase-based endpoints
-  app.get('/api/requests', authenticateUser, async (req, res) => {
-    logger.info('GET /api/requests route hit');
-
-    if (req.user) {
-      try {
-        const { data: requests, error } = await supabase
-          .from('requests')
-          .select('*')
-          .order('created_at', { ascending: false });
-
-        if (error) {
-          logger.warn('Requests fetch error, returning empty array:', error);
-          return res.json([]);
-        }
-
-        return res.json(requests || []);
-      } catch (error) {
-        logger.error('Error in /api/requests:', error);
-        return res.json([]);
-      }
-    }
-
-    return res.status(401).json({ message: 'Not authenticated' });
-  });
 
   app.get('/api/debug/permissions', authenticateUser, async (req, res) => {
     if (!req.user) {


### PR DESCRIPTION
## Summary
- create mock data for requests
- expose `authRoutes.getRequests` for returning requests
- wire `/api/requests` in server index
- remove old requests route

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_685553118d4c8320ac32fa04acbc1958