### PR TITLE
Fix vite proxy configuration for API

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -39,6 +39,7 @@ export default defineConfig({
       '/api': {
         target: 'http://localhost:3001',
         changeOrigin: true,
+        secure: false,
       },
       // Можно добавить любые другие эндпоинты
     },


### PR DESCRIPTION
## Summary
- forward API requests to Express server

## Testing
- `npm run check`
- `npm run dev` *(fails: Cannot find module '@rollup/rollup-linux-x64-gnu')*

------
https://chatgpt.com/codex/tasks/task_e_6855645874cc8320a68b810beecb1595