### PR TITLE
Fix task form logging and user dropdown

### DIFF
--- a/client/src/pages/tasks/CreateTaskDialog.tsx
+++ b/client/src/pages/tasks/CreateTaskDialog.tsx
@@ -21,7 +21,17 @@ interface Props {
   form: UseFormReturn<TaskFormData>;
   onSubmit: (data: TaskFormData) => void;
   loading: boolean;
-  users: { id: number; firstName: string; lastName: string; role: string }[] | undefined;
+  users:
+    | {
+        id: number;
+        firstName?: string;
+        lastName?: string;
+        first_name?: string;
+        last_name?: string;
+        name?: string;
+        role: string;
+      }[]
+    | undefined;
 }
 
 export default function CreateTaskDialog({ open, onOpenChange, form, onSubmit, loading, users }: Props) {
@@ -31,7 +41,15 @@ export default function CreateTaskDialog({ open, onOpenChange, form, onSubmit, l
     logger.info('CreateTaskDialog open state changed:', open);
   }, [open]);
 
+  useEffect(() => {
+    console.log('\u{1F465} Users for dropdown:', users);
+    users?.forEach(user => {
+      console.log('User:', user.name, user.first_name, user.last_name, user.role);
+    });
+  }, [users]);
+
   const handleSubmit = (data: TaskFormData) => {
+    console.log('\u{1F501} Form submit triggered');
     logger.info('CreateTaskDialog form submit', data);
     onSubmit(data);
   };
@@ -89,7 +107,7 @@ export default function CreateTaskDialog({ open, onOpenChange, form, onSubmit, l
               placeholder={t('task.select_assignee')}
               options={(users || []).map(u => ({
                 value: u.id,
-                label: `${u.firstName} ${u.lastName} (${t(`role.${u.role}`)})`,
+                label: `${u.name || `${u.first_name ?? u.firstName ?? ''} ${u.last_name ?? u.lastName ?? ''}`.trim()} (${u.role})`,
               }))}
             />
             {!users || users.length === 0 ? (
@@ -133,6 +151,10 @@ export default function CreateTaskDialog({ open, onOpenChange, form, onSubmit, l
               <Button
                 type="submit"
                 disabled={loading || !users || users.length === 0}
+                onClick={() => {
+                  console.log('\u{1F534} Create button clicked');
+                  console.log('Form data:', form.getValues());
+                }}
               >
                 {t('task.create')}
               </Button>

--- a/client/src/pages/tasks/useTasks.ts
+++ b/client/src/pages/tasks/useTasks.ts
@@ -30,7 +30,15 @@ export function useTasks() {
   const queryClient = useQueryClient();
   const { user } = useAuth();
 
-  const { data: users, isLoading: usersLoading } = useQuery<{ id: number; firstName: string; lastName: string; role: string }[]>({
+  const { data: users, isLoading: usersLoading } = useQuery<{
+    id: number;
+    firstName?: string;
+    lastName?: string;
+    first_name?: string;
+    last_name?: string;
+    name?: string;
+    role: string;
+  }[]>({
     queryKey: [user?.role === 'admin' ? '/api/users' : '/api/users/chat'],
     enabled: !!user,
     staleTime: 1000 * 60 * 5,


### PR DESCRIPTION
## Summary
- improve user type handling in tasks hooks
- add debug logs for loading users in CreateTaskDialog
- log form submission and create button click
- show user display name with new format

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_68558691d9688320bc1666df2d8eb2f5