### PR TITLE
Fix form submission in CreateTaskDialog

### DIFF
--- a/client/src/pages/tasks/CreateTaskDialog.tsx
+++ b/client/src/pages/tasks/CreateTaskDialog.tsx
@@ -151,9 +151,10 @@ export default function CreateTaskDialog({ open, onOpenChange, form, onSubmit, l
               <Button
                 type="submit"
                 disabled={loading || !users || users.length === 0}
-                onClick={() => {
+                onClick={e => {
                   console.log('\u{1F534} Create button clicked');
                   console.log('Form data:', form.getValues());
+                  form.handleSubmit(handleSubmit)(e);
                 }}
               >
                 {t('task.create')}


### PR DESCRIPTION
## Summary
- ensure clicking the create button submits the form

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_6855888d7c948320bebccd462ece958e