### PR TITLE
Remove clientId from create task dialog

### DIFF
--- a/client/src/pages/tasks/CreateTaskDialog.tsx
+++ b/client/src/pages/tasks/CreateTaskDialog.tsx
@@ -52,10 +52,15 @@ export default function CreateTaskDialog({ open, onOpenChange, form, onSubmit, l
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
-    const rawData = form.getValues();
+    const formData = form.getValues();
     const taskData = {
-      ...rawData,
-      clientId: 1,
+      title: formData.title,
+      description: formData.description,
+      status: formData.status,
+      priority: formData.priority,
+      executorId: formData.executorId,
+      dueDate: formData.dueDate,
+      // Убрать clientId полностью - пусть API сам его определит
     };
     console.log('📝 Submitting task:', taskData);
     console.log('📋 Task data being sent:', JSON.stringify(taskData, null, 2));


### PR DESCRIPTION
## Summary
- update CreateTaskDialog to drop `clientId` and build task payload manually

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68566da135c883209bc5b49ee61567f0