### PR TITLE
Fix authorization in task creation

### DIFF
--- a/server/db/storage.ts
+++ b/server/db/storage.ts
@@ -54,6 +54,10 @@ export class SupabaseStorage {
   async getUserByEmail(email: string): Promise<User | undefined> {
     return this.usersRepo.getUserByEmail(email);
   }
+
+  async getUserByAuthId(authUserId: string): Promise<User | undefined> {
+    return this.usersRepo.getUserByAuthId(authUserId);
+  }
   
   async getUsersByRole(role: string): Promise<User[]> {
     return this.usersRepo.getUsersByRole(role);

--- a/server/db/users/repository.ts
+++ b/server/db/users/repository.ts
@@ -27,6 +27,14 @@ export class UsersRepository {
     return users[0];
   }
 
+  async getUserByAuthId(authUserId: string): Promise<User | undefined> {
+    const users = await this.database.select()
+      .from(schema.users)
+      .where(eq(schema.users.authUserId, authUserId))
+      .limit(1);
+    return users[0];
+  }
+
   async getUsersByRole(role: string): Promise<User[]> {
     return this.database.select()
       .from(schema.users)

--- a/server/routes/tasks.ts
+++ b/server/routes/tasks.ts
@@ -156,19 +156,31 @@ app.post('/api/tasks', authenticateUser, async (req, res) => {
     logger.info('🔍 AUTH DEBUG - req.user:', req.user);
     logger.info('🔍 AUTH DEBUG - req.user.id:', req.user?.id);
     logger.info('🔍 AUTH DEBUG - req.user.role:', req.user?.role);
+
+    // Получить пользователя из базы данных по Supabase UUID
+    const user = await getStorage().getUserByAuthId(req.user!.id);
+
+    logger.info('🔍 AUTH DEBUG - database user:', user);
+
+    if (!user) {
+      return res.status(401).json({
+        message: "User not found in database"
+      });
+    }
+
     logger.info('🔍 AUTH DEBUG - taskData.clientId:', taskData.clientId);
-    logger.info('🔍 AUTH DEBUG - comparison result:', req.user!.role !== 'admin' && taskData.clientId !== req.user!.id);
+    logger.info('🔍 AUTH DEBUG - comparison result:', user.role !== 'admin' && taskData.clientId !== user.id);
     
     // Устанавливаем текущего пользователя как клиента, если не указано иное
     if (!taskData.clientId) {
-      taskData.clientId = req.user!.id;
+      taskData.clientId = user.id;
     }
-    
+
     // Администраторы могут создавать задачи от имени любого пользователя
     // Обычные пользователи могут создавать задачи только от своего имени
-    if (req.user!.role !== 'admin' && taskData.clientId !== req.user!.id) {
-      return res.status(403).json({ 
-        message: "Forbidden - You can only create tasks on your own behalf", 
+    if (user.role !== 'admin' && taskData.clientId !== user.id) {
+      return res.status(403).json({
+        message: "Forbidden - You can only create tasks on your own behalf",
         details: "Regular users can only create tasks where they are the client"
       });
     }

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -30,6 +30,7 @@ export interface IStorage {
   getUsers(): Promise<User[]>;
   getUser(id: number): Promise<User | undefined>;
   getUserByEmail(email: string): Promise<User | undefined>;
+  getUserByAuthId(authUserId: string): Promise<User | undefined>;
   getUsersByRole(
     role: 'student' | 'teacher' | 'admin' | 'director'
   ): Promise<User[]>;
@@ -315,6 +316,10 @@ export class MemStorage implements IStorage {
   
   async getUserByEmail(email: string): Promise<User | undefined> {
     return Array.from(this.users.values()).find(user => user.email === email);
+  }
+
+  async getUserByAuthId(authUserId: string): Promise<User | undefined> {
+    return Array.from(this.users.values()).find(user => user.authUserId === authUserId);
   }
   
   async createUser(userData: InsertUser): Promise<User> {

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -20,6 +20,7 @@ export const users = pgTable("users", {
   firstName: text("first_name").notNull(),
   lastName: text("last_name").notNull(),
   password: text("password").notNull(),
+  authUserId: text("auth_user_id"),
   email: text("email").notNull().unique(),
   role: roleEnum("role").notNull(),
   createdAt: timestamp("created_at").defaultNow(),


### PR DESCRIPTION
## Summary
- add authUserId column to users table
- expose getUserByAuthId in storage interfaces
- fetch proper database user in task creation route

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_685678e5af50832086a65278c65b5944