### PR TITLE
Add publicId to user API and use it in tasks

### DIFF
--- a/client/src/hooks/use-auth.tsx
+++ b/client/src/hooks/use-auth.tsx
@@ -5,7 +5,16 @@ import {
   UseMutationResult,
   useQueryClient
 } from "@tanstack/react-query";
-import { User } from "@shared/schema";
+
+// Тип пользователя, возвращаемого эндпоинтом /api/user
+export interface AuthUser {
+  id: string; // UUID из auth.users
+  publicId: number; // числовой ID из public.users
+  firstName: string;
+  lastName: string;
+  email: string;
+  role: string;
+}
 import { useToast } from "@/hooks/use-toast";
 import { supabase } from '@/lib/supabase';
 import { authFetch } from '@/lib/queryClient';
@@ -36,13 +45,13 @@ const dispatchAuthStatusChanged = (isAuthenticated: boolean) => {
 };
 
 type AuthContextType = {
-  user: User | null;
+  user: AuthUser | null;
   isLoading: boolean;
   error: Error | null;
   isAuthenticated: boolean;
-  loginMutation: UseMutationResult<User, Error, LoginData>;
+  loginMutation: UseMutationResult<AuthUser, Error, LoginData>;
   logoutMutation: UseMutationResult<void, Error, void>;
-  registerMutation: UseMutationResult<User, Error, RegisterData>;
+  registerMutation: UseMutationResult<AuthUser, Error, RegisterData>;
 };
 
 type LoginData = {
@@ -69,7 +78,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     data: user,
     error,
     isLoading,
-  } = useQuery<User | null, Error>({
+  } = useQuery<AuthUser | null, Error>({
     queryKey: ["/api/user"],
     queryFn: async () => {
       try {
@@ -168,7 +177,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       }
       return await res.json();
     },
-    onSuccess: (userData: User) => {
+    onSuccess: (userData: AuthUser) => {
       queryClient.setQueryData(["/api/user"], userData);
       // Explicitly set authentication status to true
       dispatchAuthStatusChanged(true);
@@ -231,7 +240,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       }
       return await res.json();
     },
-    onSuccess: (userData: User) => {
+    onSuccess: (userData: AuthUser) => {
       queryClient.setQueryData(["/api/user"], userData);
       // Set authentication status to true for new users
       dispatchAuthStatusChanged(true);

--- a/client/src/pages/tasks/CreateTaskDialog.tsx
+++ b/client/src/pages/tasks/CreateTaskDialog.tsx
@@ -15,6 +15,7 @@ import { logger } from '@/lib/logger';
 import { TaskFormData } from './useTasks';
 import { useEffect } from 'react';
 import { supabase } from '@/lib/supabase';
+import { useAuth } from '@/hooks/use-auth';
 
 interface Props {
   open: boolean;
@@ -37,6 +38,7 @@ interface Props {
 
 export default function CreateTaskDialog({ open, onOpenChange, form, onSubmit, loading, users }: Props) {
   const { t } = useTranslation();
+  const { user } = useAuth();
 
   useEffect(() => {
     logger.info('CreateTaskDialog open state changed:', open);
@@ -60,7 +62,7 @@ export default function CreateTaskDialog({ open, onOpenChange, form, onSubmit, l
       priority: formData.priority,
       executorId: formData.executorId,
       dueDate: formData.dueDate,
-      clientId: 1 as number,
+      clientId: user?.publicId as number,
     };
     console.log('📝 Submitting task:', taskData);
     console.log('📋 Task data being sent:', JSON.stringify(taskData, null, 2));

--- a/client/src/pages/tasks/useTasks.ts
+++ b/client/src/pages/tasks/useTasks.ts
@@ -183,7 +183,7 @@ export function useTasks() {
       ...data,
       description: data.description || '',
       dueDate: data.dueDate ? data.dueDate.toISOString() : null,
-      clientId: 1, // Используем ID из public.users для текущего пользователя
+      clientId: user?.publicId as number, // Используем ID из public.users для текущего пользователя
     } as InsertTask;
     createTaskMutation.mutate(taskData);
   };

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -253,7 +253,8 @@ export function setupAuth(app: Express) {
 
         // Возвращаем данные пользователя
         return res.json({
-          id: userData.auth_user_id,
+          id: userData.auth_user_id, // UUID из таблицы auth.users
+          publicId: userData.id, // числовой ID из public.users
           firstName: userData.first_name,
           lastName: userData.last_name,
           email: userData.email,


### PR DESCRIPTION
## Summary
- extend `/api/user` to return numeric `publicId`
- fetch auth user in task creation dialog and use numeric ID
- update task hooks to send current user's `publicId`
- define `AuthUser` type in auth hook

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6856874ce5748320954917589bf38d8f