### PR TITLE
Fix user list query and notification error handling

### DIFF
--- a/server/routes/notifications.ts
+++ b/server/routes/notifications.ts
@@ -10,8 +10,9 @@ export function registerNotificationRoutes(app: Express, { authenticateUser, req
       const userId = req.user!.id;
       const notifications = await getStorage().getNotificationsByUser(userId);
       res.json(notifications);
-    } catch {
-      res.status(500).json({ message: "Server error" });
+    } catch (error) {
+      console.error('Notifications error:', error);
+      return res.json([]);
     }
   });
 


### PR DESCRIPTION
## Summary
- fix `/api/users` to check user permissions via `getDbUserBySupabaseUser`
- query users directly using Drizzle and return basic info sorted by name
- return empty array on `/api/notifications` error

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_6856b45036a88320890e00e780526e9a