### PR TITLE
Fix task dialog hooks and clean user logs

### DIFF
--- a/client/src/pages/tasks/EditTaskDialog.tsx
+++ b/client/src/pages/tasks/EditTaskDialog.tsx
@@ -11,7 +11,7 @@ import { format } from 'date-fns';
 import { cn } from '@/lib/utils';
 import { UseFormReturn } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
-import { TaskFormData } from './useTasks';
+import { TaskFormData, type UserSummary } from './useTasks';
 
 interface Props {
   open: boolean;
@@ -19,7 +19,7 @@ interface Props {
   form: UseFormReturn<TaskFormData>;
   onSubmit: (data: TaskFormData) => void;
   loading: boolean;
-  users: { id: number; firstName: string; lastName: string; role: string }[] | undefined;
+  users: UserSummary[] | undefined;
 }
 
 export default function EditTaskDialog({ open, onOpenChange, form, onSubmit, loading, users }: Props) {

--- a/client/src/pages/tasks/Tasks.tsx
+++ b/client/src/pages/tasks/Tasks.tsx
@@ -84,11 +84,6 @@ const TasksPage = () => {
     createTask(data);
   };
 
-  const handleTaskCreated = () => {
-    queryClient.invalidateQueries({ queryKey: ['/api/tasks'] });
-    setCreateDialogOpen(false);
-    form.reset();
-  };
 
   useEffect(() => {
     if (createTaskMutation.isSuccess) {
@@ -122,7 +117,7 @@ const TasksPage = () => {
           form={form}
           loading={createTaskMutation.isPending}
           users={users}
-          onTaskCreated={handleTaskCreated}
+          onSubmit={onSubmit}
         />
       </div>
 

--- a/client/src/pages/tasks/useTasks.ts
+++ b/client/src/pages/tasks/useTasks.ts
@@ -5,7 +5,9 @@ import { useTranslation } from 'react-i18next';
 import { useAuth } from '@/hooks/use-auth';
 import { useToast } from '@/hooks/use-toast';
 import { apiRequest } from '@/lib/queryClient';
-import { insertTaskSchema, type InsertTask } from '@shared/schema';
+import { insertTaskSchema, type InsertTask, type UserSummary as SharedUserSummary } from '@shared/schema';
+
+export type UserSummary = SharedUserSummary;
 
 export interface Task {
   id: number;
@@ -30,15 +32,7 @@ export function useTasks() {
   const queryClient = useQueryClient();
   const { user } = useAuth();
 
-  const { data: users, isLoading: usersLoading } = useQuery<{
-    id: number;
-    firstName?: string;
-    lastName?: string;
-    first_name?: string;
-    last_name?: string;
-    name?: string;
-    role: string;
-  }[]>({
+  const { data: users, isLoading: usersLoading } = useQuery<UserSummary[]>({
     queryKey: [user?.role === 'admin' ? '/api/users' : '/api/users/chat'],
     enabled: !!user,
     staleTime: 1000 * 60 * 5,

--- a/server/routes/users.ts
+++ b/server/routes/users.ts
@@ -15,13 +15,6 @@ export function registerUserRoutes(app: Express, { authenticateUser, requireRole
   app.get('/api/users', authenticateUser, async (req, res) => {
     logger.info('GET /api/users route hit');
 
-    // Detailed debug logging for troubleshooting role checks
-    console.log('=== getUsers function called ===');
-    console.log('User object:', JSON.stringify(req.user, null, 2));
-    console.log('User metadata:', req.user?.user_metadata);
-    console.log('User role from metadata:', req.user?.user_metadata?.role);
-    console.log('================================');
-
     if (!req.user) {
       return res.status(401).json({ message: 'Not authenticated' });
     }
@@ -42,7 +35,6 @@ export function registerUserRoutes(app: Express, { authenticateUser, requireRole
         .from(schema.users)
         .orderBy(schema.users.firstName, schema.users.lastName);
 
-      console.log('Users for dropdown:', users);
       return res.json(users);
     } catch (error) {
       logger.error('Error in /api/users:', error);


### PR DESCRIPTION
## Summary
- use common `UserSummary` type in task dialogs
- simplify create task dialog to rely on hook
- pass submit handler from page
- export `UserSummary` from `useTasks`
- remove debug logging from user routes

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6856b643694083208b6a92c838076ad2