### PR TITLE
Improve task logging

### DIFF
--- a/client/src/hooks/use-auth.tsx
+++ b/client/src/hooks/use-auth.tsx
@@ -89,7 +89,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         }
         
         const { data: sessionData } = await supabase.auth.getSession();
-        devLog('Supabase access token:', sessionData.session?.access_token);
+        // devLog('Supabase access token:', sessionData.session?.access_token);
 
         const fetchOptions: RequestInit = {
           method: 'GET',
@@ -150,7 +150,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         throw new Error(error.message);
       }
       const { data: sessionData } = await supabase.auth.getSession();
-      devLog('Supabase access token:', sessionData.session?.access_token);
+      // devLog('Supabase access token:', sessionData.session?.access_token);
 
       const fetchOptions: RequestInit = {
         method: 'GET',
@@ -213,7 +213,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         throw new Error(error.message);
       }
       const { data: sessionData } = await supabase.auth.getSession();
-      devLog('Supabase access token:', sessionData.session?.access_token);
+      // devLog('Supabase access token:', sessionData.session?.access_token);
 
       const fetchOptions: RequestInit = {
         method: 'GET',

--- a/server/routes/tasks.ts
+++ b/server/routes/tasks.ts
@@ -155,11 +155,13 @@ app.post('/api/tasks', authenticateUser, async (req, res) => {
       dueDate: z.string().nullable().transform(val => val ? new Date(val) : null)
     });
     
-    logger.info('Received task data:', req.body);
+    logger.info('Request body:', req.body);
     const taskData = modifiedTaskSchema.parse(req.body);
     logger.info('Parsed task data:', taskData);
+    const dbUser = await getDbUserBySupabaseUser(req.user!);
+    logger.info("DB user:", dbUser);
 
-    const { id: userId, role: userRole } = await getDbUserBySupabaseUser(req.user!);
+    const { id: userId, role: userRole } = dbUser;
 
     logger.info('User permissions check:', {
       email: req.user!.email,
@@ -289,7 +291,10 @@ app.put('/api/tasks/:id', authenticateUser, async (req, res) => {
       });
     }
     
-    const { id: userId, role: userRole } = await getDbUserBySupabaseUser(req.user!);
+    logger.info("Request body:", req.body);
+    const dbUser = await getDbUserBySupabaseUser(req.user!);
+    logger.info("DB user:", dbUser);
+    const { id: userId, role: userRole } = dbUser;
     const isAdmin = userRole === 'admin';
     const isCreator = task.clientId === userId;
     const isExecutor = task.executorId === userId;


### PR DESCRIPTION
## Summary
- suppress noisy Supabase token logs in auth hook
- log request details and resolved DB user for task creation and update

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6856cfb7d9688320bff8481d3a0a7291