### PR TITLE
Add debug logs for task creation

### DIFF
--- a/client/src/pages/tasks/CreateTaskDialog.tsx
+++ b/client/src/pages/tasks/CreateTaskDialog.tsx
@@ -27,7 +27,9 @@ export default function CreateTaskDialog({ open, onOpenChange, form, loading, us
 
 
   const handleSubmit = form.handleSubmit(data => {
+    console.log('🔵 CreateTaskDialog: handleSubmit called with:', data);
     onSubmit?.(data);
+    console.log('🔵 CreateTaskDialog: onSubmit called');
   });
 
   return (

--- a/client/src/pages/tasks/Tasks.tsx
+++ b/client/src/pages/tasks/Tasks.tsx
@@ -80,8 +80,10 @@ const TasksPage = () => {
     editTask(currentTask.id, data);
   };
 
-  const onSubmit = (data: TaskFormData) => {
+  const handleCreateTask = (data: TaskFormData) => {
+    console.log('🟢 Tasks.tsx: handleCreateTask called with:', data);
     createTask(data);
+    console.log('🟢 Tasks.tsx: createTask called');
   };
 
 
@@ -117,7 +119,7 @@ const TasksPage = () => {
           form={form}
           loading={createTaskMutation.isPending}
           users={users}
-          onSubmit={onSubmit}
+          onSubmit={handleCreateTask}
         />
       </div>
 

--- a/client/src/pages/tasks/useTasks.ts
+++ b/client/src/pages/tasks/useTasks.ts
@@ -69,7 +69,9 @@ export function useTasks() {
 
   const createTaskMutation = useMutation({
     mutationFn: async (data: InsertTask) => {
+      console.log('🟠 Mutation: starting POST with data:', data);
       const result = await apiRequest('/api/tasks', 'POST', data);
+      console.log('🟠 Mutation: POST result:', result);
       return result;
     },
     onSuccess: () => {
@@ -165,7 +167,11 @@ export function useTasks() {
   });
 
   const createTask = (data: TaskFormData) => {
+    console.log('🟡 useTasks: createTask called with:', data);
+    console.log('🟡 useTasks: user:', user);
+
     if (!user?.id) {
+      console.log('❌ useTasks: No user ID!');
       toast({
         title: t('task.error_creating'),
         description: t('auth.user_not_found'),
@@ -173,13 +179,17 @@ export function useTasks() {
       });
       return;
     }
+
     const taskData = {
       ...data,
       description: data.description || '',
       dueDate: data.dueDate ? data.dueDate.toISOString() : null,
-      clientId: user?.publicId as number, // Используем ID из public.users для текущего пользователя
+      clientId: user?.publicId as number,
     } as InsertTask;
+
+    console.log('🟡 useTasks: taskData prepared:', taskData);
     createTaskMutation.mutate(taskData);
+    console.log('🟡 useTasks: mutation called');
   };
 
   const editTask = (id: number, data: TaskFormData) => {


### PR DESCRIPTION
## Summary
- add debug logs in CreateTaskDialog
- add debug logs in Tasks page and pass handleCreateTask handler
- log details in `useTasks` including mutation

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6856d60ef76c832093cdb34edac7a5f1