### PR TITLE
Add extensive logging for task creation

### DIFF
--- a/client/src/pages/tasks/CreateTaskDialog.tsx
+++ b/client/src/pages/tasks/CreateTaskDialog.tsx
@@ -12,6 +12,7 @@ import { cn } from '@/lib/utils';
 import { UseFormReturn } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { TaskFormData, type UserSummary } from './useTasks';
+import React from 'react';
 
 interface Props {
   open: boolean;
@@ -25,12 +26,33 @@ interface Props {
 export default function CreateTaskDialog({ open, onOpenChange, form, loading, users, onSubmit }: Props) {
   const { t } = useTranslation();
 
-
-  const handleSubmit = form.handleSubmit(data => {
-    console.log('🔵 CreateTaskDialog: handleSubmit called with:', data);
-    onSubmit?.(data);
-    console.log('🔵 CreateTaskDialog: onSubmit called');
+  // Render logs
+  console.log('🟦 CreateTaskDialog: Component rendered');
+  console.log('🟦 CreateTaskDialog: Props:', {
+    open,
+    loading,
+    users: users?.length,
+    onSubmit: !!onSubmit,
   });
+  console.log('🟦 CreateTaskDialog: Form state:', form.formState);
+  console.log('🟦 CreateTaskDialog: Form errors:', form.formState.errors);
+
+  const handleSubmit = form.handleSubmit(
+    (data) => {
+      console.log('🔵 CreateTaskDialog: handleSubmit SUCCESS with:', data);
+      onSubmit?.(data);
+      console.log('🔵 CreateTaskDialog: onSubmit called');
+    },
+    (errors) => {
+      console.log('❌ CreateTaskDialog: handleSubmit VALIDATION ERRORS:', errors);
+    }
+  );
+
+  const handleButtonClick = (e: React.FormEvent) => {
+    console.log('🔷 CreateTaskDialog: Button clicked!');
+    console.log('🔷 CreateTaskDialog: Form isValid:', form.formState.isValid);
+    console.log('🔷 CreateTaskDialog: Button disabled:', loading || !users || users.length === 0);
+  };
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -128,6 +150,7 @@ export default function CreateTaskDialog({ open, onOpenChange, form, loading, us
               <Button
                 type="submit"
                 disabled={loading || !users || users.length === 0}
+                onClick={handleButtonClick}
               >
                 {t('task.create')}
               </Button>

--- a/client/src/pages/tasks/Tasks.tsx
+++ b/client/src/pages/tasks/Tasks.tsx
@@ -18,6 +18,7 @@ const TasksPage = () => {
   const { t } = useTranslation();
   const { user } = useAuth();
   const queryClient = useQueryClient();
+  console.log('🟢 Tasks.tsx: Component rendered');
   const {
     tasks,
     tasksLoading,
@@ -32,6 +33,15 @@ const TasksPage = () => {
     updateTaskMutation,
     deleteTaskMutation,
   } = useTasks();
+  console.log('🟢 Tasks.tsx: createTask available:', !!createTask);
+
+  const handleCreateTask = (data: TaskFormData) => {
+    console.log('🟢 Tasks.tsx: handleCreateTask called with:', data);
+    createTask(data);
+    console.log('🟢 Tasks.tsx: createTask called');
+  };
+
+  console.log('🟢 Tasks.tsx: handleCreateTask defined:', !!handleCreateTask);
 
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
   const [editDialogOpen, setEditDialogOpen] = useState(false);
@@ -78,12 +88,6 @@ const TasksPage = () => {
   const onEditSubmit = (data: TaskFormData) => {
     if (!currentTask) return;
     editTask(currentTask.id, data);
-  };
-
-  const handleCreateTask = (data: TaskFormData) => {
-    console.log('🟢 Tasks.tsx: handleCreateTask called with:', data);
-    createTask(data);
-    console.log('🟢 Tasks.tsx: createTask called');
   };
 
 

--- a/client/src/pages/tasks/useTasks.ts
+++ b/client/src/pages/tasks/useTasks.ts
@@ -27,10 +27,12 @@ export interface Task {
 export type TaskFormData = InsertTask;
 
 export function useTasks() {
+  console.log('🟡 useTasks: Hook called');
   const { t } = useTranslation();
   const { toast } = useToast();
   const queryClient = useQueryClient();
   const { user } = useAuth();
+  console.log('🟡 useTasks: user from context:', user);
 
   const { data: users, isLoading: usersLoading } = useQuery<UserSummary[]>({
     queryKey: [user?.role === 'admin' ? '/api/users' : '/api/users/chat'],
@@ -75,6 +77,7 @@ export function useTasks() {
       return result;
     },
     onSuccess: () => {
+      console.log('✅ Mutation: SUCCESS');
       queryClient.invalidateQueries({ queryKey: ['/api/tasks'] });
       toast({
         title: t('task.created_success'),
@@ -82,6 +85,7 @@ export function useTasks() {
       });
     },
     onError: (error: any) => {
+      console.log('❌ Mutation: ERROR:', error);
       const errorMessage = error?.message || error?.error?.message || t('task.try_again');
       toast({
         title: t('task.error_creating'),
@@ -191,6 +195,7 @@ export function useTasks() {
     createTaskMutation.mutate(taskData);
     console.log('🟡 useTasks: mutation called');
   };
+  console.log('🟡 useTasks: createTask function defined:', !!createTask);
 
   const editTask = (id: number, data: TaskFormData) => {
     const taskData = {


### PR DESCRIPTION
## Summary
- add detailed log messages to CreateTaskDialog
- log component state in Tasks page
- add verbose logs and mutation reporting in `useTasks` hook

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6856d9da75fc8320a775dce708c77aba