### PR TITLE
Fix form schemas to exclude context fields

### DIFF
--- a/client/src/components/requests/RequestForm.tsx
+++ b/client/src/components/requests/RequestForm.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import { insertRequestSchema } from '@shared/schema';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
@@ -10,20 +9,22 @@ import { Textarea } from '@/components/ui/textarea';
 import { Button } from '@/components/ui/button';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 
-// Extended schema with validation rules for forms
-const requestFormSchema = insertRequestSchema.extend({
+// Schema for the request form (studentId is added automatically on the server)
+export const requestFormSchema = z.object({
   type: z.string().min(3, "Request type is required"),
   description: z.string().min(10, "Description must be at least 10 characters"),
 });
 
+export type RequestFormData = z.infer<typeof requestFormSchema>;
+
 interface RequestFormProps {
-  onSubmit: (data: z.infer<typeof requestFormSchema>) => Promise<void>;
+  onSubmit: (data: RequestFormData) => Promise<void>;
 }
 
 const RequestForm: React.FC<RequestFormProps> = ({ onSubmit }) => {
   const [isSubmitting, setIsSubmitting] = useState(false);
   
-  const form = useForm<z.infer<typeof requestFormSchema>>({
+  const form = useForm<RequestFormData>({
     resolver: zodResolver(requestFormSchema),
     defaultValues: {
       type: '',
@@ -39,7 +40,7 @@ const RequestForm: React.FC<RequestFormProps> = ({ onSubmit }) => {
     { value: 'other', label: 'Other' },
   ];
   
-  const handleSubmit = async (data: z.infer<typeof requestFormSchema>) => {
+  const handleSubmit = async (data: RequestFormData) => {
     try {
       setIsSubmitting(true);
       await onSubmit(data);

--- a/client/src/pages/requests/Requests.tsx
+++ b/client/src/pages/requests/Requests.tsx
@@ -10,8 +10,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { postData, putData } from '@/lib/api';
 import { useToast } from '@/hooks/use-toast';
 import { Request, User } from '@shared/schema';
-import { z } from 'zod';
-import { insertRequestSchema } from '@shared/schema';
+import { type RequestFormData } from '@/components/requests/RequestForm';
 import { useLocation } from 'wouter';
 
 const Requests = () => {
@@ -37,7 +36,7 @@ const Requests = () => {
   
   // Mutation for creating requests (student)
   const createRequestMutation = useMutation({
-    mutationFn: (data: z.infer<typeof insertRequestSchema>) => {
+    mutationFn: (data: RequestFormData) => {
       return postData('/api/requests', data);
     },
     onSuccess: () => {
@@ -79,7 +78,7 @@ const Requests = () => {
     },
   });
   
-  const handleSubmitRequest = async (data: z.infer<typeof insertRequestSchema>) => {
+  const handleSubmitRequest = async (data: RequestFormData) => {
     await createRequestMutation.mutateAsync(data);
   };
   

--- a/client/src/pages/tasks/useTasks.ts
+++ b/client/src/pages/tasks/useTasks.ts
@@ -6,6 +6,7 @@ import { useAuth } from '@/hooks/use-auth';
 import { useToast } from '@/hooks/use-toast';
 import { apiRequest } from '@/lib/queryClient';
 import { insertTaskSchema, type InsertTask, type UserSummary as SharedUserSummary } from '@shared/schema';
+import { z } from 'zod';
 
 export type UserSummary = SharedUserSummary;
 
@@ -24,7 +25,16 @@ export interface Task {
   executor?: { firstName: string; lastName: string };
 }
 
-export type TaskFormData = InsertTask;
+const taskFormSchema = z.object({
+  title: z.string().min(1),
+  description: z.string().optional(),
+  priority: z.enum(['high', 'medium', 'low']),
+  status: z.enum(['new', 'in_progress', 'on_hold']),
+  executorId: z.number(),
+  dueDate: z.date().nullable().optional(),
+});
+
+export type TaskFormData = z.infer<typeof taskFormSchema>;
 
 export function useTasks() {
   console.log('🟡 useTasks: Hook called');
@@ -46,7 +56,7 @@ export function useTasks() {
   });
 
   const form = useForm<TaskFormData>({
-    resolver: zodResolver(insertTaskSchema),
+    resolver: zodResolver(taskFormSchema),
     defaultValues: {
       title: '',
       description: '',
@@ -58,7 +68,7 @@ export function useTasks() {
   });
 
   const editForm = useForm<TaskFormData>({
-    resolver: zodResolver(insertTaskSchema),
+    resolver: zodResolver(taskFormSchema),
     defaultValues: {
       title: '',
       description: '',


### PR DESCRIPTION
## Summary
- define `taskFormSchema` without `clientId`
- remove `studentId` from request form schema
- update requests page to use new request form type

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6856dc7bc598832098089bee617ad043