### PR TITLE
Fix role handling and typing

### DIFF
--- a/client/src/hooks/use-auth.tsx
+++ b/client/src/hooks/use-auth.tsx
@@ -6,6 +6,9 @@ import {
   useQueryClient
 } from "@tanstack/react-query";
 
+// Строгие типы ролей
+export type UserRole = 'admin' | 'teacher' | 'student';
+
 // Тип пользователя, возвращаемого эндпоинтом /api/user
 export interface AuthUser {
   id: string; // UUID из auth.users
@@ -13,7 +16,7 @@ export interface AuthUser {
   firstName: string;
   lastName: string;
   email: string;
-  role: string;
+  role: UserRole;
 }
 import { useToast } from "@/hooks/use-toast";
 import { supabase } from '@/lib/supabase';

--- a/server/middleware/requireRole.ts
+++ b/server/middleware/requireRole.ts
@@ -1,0 +1,14 @@
+import { NextFunction, Response } from 'express';
+import type { AuthenticatedRequest, UserRole } from '../types/auth';
+
+export function requireRole(allowedRoles: UserRole[]) {
+  return (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
+    const userRole = req.user?.role;
+
+    if (!userRole || !allowedRoles.includes(userRole)) {
+      return res.status(403).json({ error: 'Insufficient permissions' });
+    }
+
+    next();
+  };
+}

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -42,9 +42,11 @@ import { registerNotificationRoutes } from "./notifications";
 import { registerActivityLogRoutes } from "./activityLogs";
 import { registerCurriculumRoutes } from "./curriculum";
 import { verifySupabaseJwt } from "../middleware/verifySupabaseJwt";
+import { requireRole } from "../middleware/requireRole";
+import type { AuthenticatedUser } from "../types/auth";
 // Extend the Express Request interface
 interface Request extends ExpressRequest {
-  user?: User;
+  user?: AuthenticatedUser;
 }
 
 // Set up file upload storage
@@ -75,20 +77,6 @@ export interface RouteContext {
 
 const authenticateUser = verifySupabaseJwt;
 
-// Role check middleware
-const requireRole = (roles: string[]) => {
-  return (req: Request, res: Response, next: NextFunction) => {
-    if (!req.user) {
-      return res.status(401).json({ message: "Unauthorized" });
-    }
-    
-    if (!roles.includes(req.user!.role)) {
-      return res.status(403).json({ message: "Forbidden - Insufficient permissions" });
-    }
-    
-    next();
-  };
-};
 
 // Вспомогательная функция для получения ID преподавателя по умолчанию
 async function getDefaultTeacherId(): Promise<number> {
@@ -250,7 +238,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
 declare global {
   namespace Express {
     interface Request {
-      user?: User;
+      user?: AuthenticatedUser;
     }
   }
 }

--- a/server/types/auth.ts
+++ b/server/types/auth.ts
@@ -1,0 +1,15 @@
+export type UserRole = 'admin' | 'teacher' | 'student';
+
+export interface AuthenticatedUser {
+  id: string; // Supabase UUID
+  publicId: number; // Database ID
+  email: string;
+  firstName: string;
+  lastName: string;
+  role: UserRole;
+}
+
+import type { Request } from 'express';
+export interface AuthenticatedRequest extends Request {
+  user?: AuthenticatedUser;
+}

--- a/server/utils/userMapping.ts
+++ b/server/utils/userMapping.ts
@@ -5,14 +5,24 @@ import type { User } from '@supabase/supabase-js';
 export async function getDbUserBySupabaseUser(supabaseUser: Pick<User, 'email' | 'id'>) {
   const email = supabaseUser.email;
   if (!email) {
-    throw new Error('Supabase user does not contain an email');
+    throw new Error('User email not found');
   }
+
   try {
     const user = await getStorage().getUserByEmail(email);
     if (!user) {
-      throw new Error(`User not found: ${email}`);
+      throw new Error('User not found in database');
     }
-    return { id: user.id, role: user.role };
+
+    return {
+      id: user.id,
+      firstName: user.firstName,
+      lastName: user.lastName,
+      email: user.email,
+      role: user.role,
+      createdAt: (user as any).createdAt,
+      updatedAt: (user as any).updatedAt,
+    };
   } catch (error) {
     logger.error('User mapping error:', error);
     throw error;


### PR DESCRIPTION
## Summary
- attach full DB user with role in auth middleware
- provide helper to get all fields from user table
- create typed interfaces for authenticated requests
- introduce standalone `requireRole` middleware
- simplify `/api/user` route to use middleware data
- strictly type roles in React auth hook

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6856df063f5483208796c71aef6c54d6