### PR TITLE
Remove debug logs and improve user labels

### DIFF
--- a/client/src/i18n/locales/en.json
+++ b/client/src/i18n/locales/en.json
@@ -636,6 +636,11 @@
     "goBack": "Go back",
     "goHome": "Go home",
     "contactSupport": "Contact support",
-    "pageMissingHint": "Did you forget to add the page to the router?"
+  "pageMissingHint": "Did you forget to add the page to the router?"
+  },
+  "roles": {
+    "admin": "Administrator",
+    "teacher": "Teacher",
+    "student": "Student"
   }
 }

--- a/client/src/i18n/locales/ru.json
+++ b/client/src/i18n/locales/ru.json
@@ -570,6 +570,11 @@
     "scheduleChangedContent": "Изменения в расписании: {{info}}",
     "userProfileUpdatedByAdmin": "Ваш профиль был обновлён администратором.",
     "adminUpdatedUserProfile": "Вы обновили профиль пользователя {{name}}.",
-    "adminNotificationUserUpdated": "Профиль пользователя {{name}} был обновлён."
+  "adminNotificationUserUpdated": "Профиль пользователя {{name}} был обновлён."
+  },
+  "roles": {
+    "admin": "Администратор",
+    "teacher": "Преподаватель",
+    "student": "Студент"
   }
 }

--- a/client/src/pages/tasks/CreateTaskDialog.tsx
+++ b/client/src/pages/tasks/CreateTaskDialog.tsx
@@ -26,33 +26,13 @@ interface Props {
 export default function CreateTaskDialog({ open, onOpenChange, form, loading, users, onSubmit }: Props) {
   const { t } = useTranslation();
 
-  // Render logs
-  console.log('🟦 CreateTaskDialog: Component rendered');
-  console.log('🟦 CreateTaskDialog: Props:', {
-    open,
-    loading,
-    users: users?.length,
-    onSubmit: !!onSubmit,
-  });
-  console.log('🟦 CreateTaskDialog: Form state:', form.formState);
-  console.log('🟦 CreateTaskDialog: Form errors:', form.formState.errors);
 
   const handleSubmit = form.handleSubmit(
     (data) => {
-      console.log('🔵 CreateTaskDialog: handleSubmit SUCCESS with:', data);
       onSubmit?.(data);
-      console.log('🔵 CreateTaskDialog: onSubmit called');
     },
-    (errors) => {
-      console.log('❌ CreateTaskDialog: handleSubmit VALIDATION ERRORS:', errors);
-    }
+    () => {}
   );
-
-  const handleButtonClick = (e: React.FormEvent) => {
-    console.log('🔷 CreateTaskDialog: Button clicked!');
-    console.log('🔷 CreateTaskDialog: Form isValid:', form.formState.isValid);
-    console.log('🔷 CreateTaskDialog: Button disabled:', loading || !users || users.length === 0);
-  };
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -106,7 +86,7 @@ export default function CreateTaskDialog({ open, onOpenChange, form, loading, us
               placeholder={t('task.select_assignee')}
               options={(users || []).map(u => ({
                 value: u.id,
-                label: `${u.firstName} ${u.lastName} (${t(`role.${u.role}`)})`,
+                label: `${u.firstName} ${u.lastName} (${t(`roles.${u.role}`)})`,
               }))}
             />
             {!users || users.length === 0 ? (
@@ -150,7 +130,6 @@ export default function CreateTaskDialog({ open, onOpenChange, form, loading, us
               <Button
                 type="submit"
                 disabled={loading || !users || users.length === 0}
-                onClick={handleButtonClick}
               >
                 {t('task.create')}
               </Button>

--- a/client/src/pages/tasks/EditTaskDialog.tsx
+++ b/client/src/pages/tasks/EditTaskDialog.tsx
@@ -68,7 +68,7 @@ export default function EditTaskDialog({ open, onOpenChange, form, onSubmit, loa
               placeholder={t('task.select_assignee')}
               options={(users || []).map(u => ({
                 value: u.id,
-                label: `${u.firstName} ${u.lastName} (${t(`role.${u.role}`)})`,
+                label: `${u.firstName} ${u.lastName} (${t(`roles.${u.role}`)})`,
               }))}
             />
             <FormField

--- a/client/src/pages/tasks/Tasks.tsx
+++ b/client/src/pages/tasks/Tasks.tsx
@@ -18,7 +18,6 @@ const TasksPage = () => {
   const { t } = useTranslation();
   const { user } = useAuth();
   const queryClient = useQueryClient();
-  console.log('🟢 Tasks.tsx: Component rendered');
   const {
     tasks,
     tasksLoading,
@@ -33,15 +32,10 @@ const TasksPage = () => {
     updateTaskMutation,
     deleteTaskMutation,
   } = useTasks();
-  console.log('🟢 Tasks.tsx: createTask available:', !!createTask);
 
   const handleCreateTask = (data: TaskFormData) => {
-    console.log('🟢 Tasks.tsx: handleCreateTask called with:', data);
     createTask(data);
-    console.log('🟢 Tasks.tsx: createTask called');
   };
-
-  console.log('🟢 Tasks.tsx: handleCreateTask defined:', !!handleCreateTask);
 
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
   const [editDialogOpen, setEditDialogOpen] = useState(false);

--- a/client/src/pages/tasks/useTasks.ts
+++ b/client/src/pages/tasks/useTasks.ts
@@ -37,12 +37,10 @@ const taskFormSchema = z.object({
 export type TaskFormData = z.infer<typeof taskFormSchema>;
 
 export function useTasks() {
-  console.log('🟡 useTasks: Hook called');
   const { t } = useTranslation();
   const { toast } = useToast();
   const queryClient = useQueryClient();
   const { user } = useAuth();
-  console.log('🟡 useTasks: user from context:', user);
 
   const { data: users, isLoading: usersLoading } = useQuery<UserSummary[]>({
     queryKey: [user?.role === 'admin' ? '/api/users' : '/api/users/chat'],
@@ -81,13 +79,10 @@ export function useTasks() {
 
   const createTaskMutation = useMutation({
     mutationFn: async (data: InsertTask) => {
-      console.log('🟠 Mutation: starting POST with data:', data);
       const result = await apiRequest('/api/tasks', 'POST', data);
-      console.log('🟠 Mutation: POST result:', result);
       return result;
     },
     onSuccess: () => {
-      console.log('✅ Mutation: SUCCESS');
       queryClient.invalidateQueries({ queryKey: ['/api/tasks'] });
       toast({
         title: t('task.created_success'),
@@ -95,7 +90,6 @@ export function useTasks() {
       });
     },
     onError: (error: any) => {
-      console.log('❌ Mutation: ERROR:', error);
       const errorMessage = error?.message || error?.error?.message || t('task.try_again');
       toast({
         title: t('task.error_creating'),
@@ -181,11 +175,7 @@ export function useTasks() {
   });
 
   const createTask = (data: TaskFormData) => {
-    console.log('🟡 useTasks: createTask called with:', data);
-    console.log('🟡 useTasks: user:', user);
-
     if (!user?.id) {
-      console.log('❌ useTasks: No user ID!');
       toast({
         title: t('task.error_creating'),
         description: t('auth.user_not_found'),
@@ -201,11 +191,9 @@ export function useTasks() {
       clientId: user?.publicId as number,
     } as InsertTask;
 
-    console.log('🟡 useTasks: taskData prepared:', taskData);
     createTaskMutation.mutate(taskData);
-    console.log('🟡 useTasks: mutation called');
   };
-  console.log('🟡 useTasks: createTask function defined:', !!createTask);
+
 
   const editTask = (id: number, data: TaskFormData) => {
     const taskData = {


### PR DESCRIPTION
## Summary
- clean up console logs in task-related components
- show readable role names in task dialogs
- add global role translations

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6856e26b4108832085305e85e2a76361