### PR TITLE
Clean logs and improve user dropdown

### DIFF
--- a/client/src/pages/tasks/CreateTaskDialog.tsx
+++ b/client/src/pages/tasks/CreateTaskDialog.tsx
@@ -4,6 +4,7 @@ import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '
 import { TextField } from '@/components/forms/TextField';
 import { TextareaField } from '@/components/forms/TextareaField';
 import { SelectField } from '@/components/forms/SelectField';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Calendar } from '@/components/ui/calendar';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { CalendarIcon } from 'lucide-react';
@@ -79,15 +80,35 @@ export default function CreateTaskDialog({ open, onOpenChange, form, loading, us
                 ]}
               />
             </div>
-            <SelectField
+            <FormField
               control={form.control}
               name="executorId"
-              label={t('task.assignee')}
-              placeholder={t('task.select_assignee')}
-              options={(users || []).map(u => ({
-                value: u.id,
-                label: `${u.firstName} ${u.lastName} (${t(`roles.${u.role}`)})`,
-              }))}
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>{t('task.assignee')}</FormLabel>
+                  <Select
+                    onValueChange={value => field.onChange(parseInt(value))}
+                    defaultValue={field.value ? String(field.value) : undefined}
+                  >
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue placeholder={t('task.select_assignee')} />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {users?.map(user => (
+                        <SelectItem key={user.id} value={user.id.toString()}>
+                          {user.firstName} {user.lastName}
+                          <span className="text-gray-500 text-sm ml-2">
+                            ({t(`roles.${user.role}`)})
+                          </span>
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
             />
             {!users || users.length === 0 ? (
               <p className="text-sm text-muted-foreground">

--- a/client/src/pages/tasks/EditTaskDialog.tsx
+++ b/client/src/pages/tasks/EditTaskDialog.tsx
@@ -4,6 +4,7 @@ import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '
 import { TextField } from '@/components/forms/TextField';
 import { TextareaField } from '@/components/forms/TextareaField';
 import { SelectField } from '@/components/forms/SelectField';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Calendar } from '@/components/ui/calendar';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { CalendarIcon } from 'lucide-react';
@@ -61,15 +62,35 @@ export default function EditTaskDialog({ open, onOpenChange, form, onSubmit, loa
                 ]}
               />
             </div>
-            <SelectField
+            <FormField
               control={form.control}
               name="executorId"
-              label={t('task.assignee')}
-              placeholder={t('task.select_assignee')}
-              options={(users || []).map(u => ({
-                value: u.id,
-                label: `${u.firstName} ${u.lastName} (${t(`roles.${u.role}`)})`,
-              }))}
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>{t('task.assignee')}</FormLabel>
+                  <Select
+                    onValueChange={value => field.onChange(parseInt(value))}
+                    defaultValue={field.value ? String(field.value) : undefined}
+                  >
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue placeholder={t('task.select_assignee')} />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {users?.map(user => (
+                        <SelectItem key={user.id} value={user.id.toString()}>
+                          {user.firstName} {user.lastName}
+                          <span className="text-gray-500 text-sm ml-2">
+                            ({t(`roles.${user.role}`)})
+                          </span>
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
             />
             <FormField
               control={form.control}

--- a/server/middleware/verifySupabaseJwt.ts
+++ b/server/middleware/verifySupabaseJwt.ts
@@ -34,10 +34,6 @@ export async function verifySupabaseJwt(req: Request, res: Response, next: NextF
     }
 
     const { data, error } = await supabase.auth.getUser(token);
-    if (process.env.NODE_ENV === 'development') {
-      logger.info('verifySupabaseJwt getUser error:', error);
-      logger.info('verifySupabaseJwt getUser data:', data);
-    }
     if (error || !data?.user) {
       return res.status(401).json({ message: 'Unauthorized' });
     }
@@ -56,6 +52,7 @@ export async function verifySupabaseJwt(req: Request, res: Response, next: NextF
     (req as any).user = mergedUser;
     next();
   } catch (err) {
-    next(err);
+    console.error('Auth middleware error:', err);
+    return res.status(401).json({ error: 'Authentication failed' });
   }
 }


### PR DESCRIPTION
## Summary
- clean up auth middleware logs
- show translated role labels in task dialogs

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6856e4c95c5c83209a8f005120d976ce