### PR TITLE
Fix duplicate keys in Russian locale

### DIFF
--- a/client/src/i18n/locales/ru.json
+++ b/client/src/i18n/locales/ru.json
@@ -481,8 +481,6 @@
     "created_description": "Задача создана и назначена выбранному пользователю",
     "updated_success": "Задача успешно обновлена",
     "updated_description": "Задача была обновлена",
-    "updated": "Задача обновлена",
-    "updated_description": "Задача была обновлена",
     "deleted_success": "Задача успешно удалена",
     "deleted_description": "Задача была удалена",
     "status_updated": "Статус обновлен",


### PR DESCRIPTION
## Summary
- remove redundant `updated` and `updated_description` entries from `ru.json`
- keep English locale unchanged

## Testing
- `npm run check`
- `npm run dev` *(fails: Cannot find module '@rollup/rollup-linux-x64-gnu')*

------
https://chatgpt.com/codex/tasks/task_e_6857c94e174c8320875c1abfb59731af