### PR TITLE
Fix Russian task status notifications

### DIFF
--- a/server/routes/tasks.ts
+++ b/server/routes/tasks.ts
@@ -349,19 +349,21 @@ app.put('/api/tasks/:id', authenticateUser, async (req, res) => {
     // Создание уведомления при изменении статуса
     if (taskData.status && taskData.status !== task.status) {
       const statusMessages = {
-        pending: 'Task moved to pending',
-        in_progress: 'Task started and is now in progress',
-        completed: 'Task completed successfully',
-        on_hold: 'Task put on hold',
-        cancelled: 'Task cancelled'
+        pending: 'Задача перемещена в ожидание',
+        in_progress: 'Задача начата и теперь выполняется',
+        completed: 'Задача успешно завершена',
+        on_hold: 'Задача приостановлена',
+        cancelled: 'Задача отменена'
       } as const;
 
-      const notificationTitle = statusMessages[taskData.status as keyof typeof statusMessages] || 'Task status updated';
+      const notificationTitle =
+        statusMessages[taskData.status as keyof typeof statusMessages] ||
+        'Статус задачи обновлен';
 
       await NotificationService.createNotification({
         userId: task.clientId,
         title: notificationTitle,
-        message: `Task "${task.title}" status changed from "${task.status}" to "${taskData.status}"`,
+        message: `Статус задачи "${task.title}" изменен с "${task.status}" на "${taskData.status}"`,
         type: 'task_update',
         relatedId: taskId,
         relatedType: 'task'
@@ -516,19 +518,21 @@ app.patch('/api/tasks/:id/status', authenticateUser, async (req, res) => {
     // Создаем уведомление при изменении статуса задачи
     if (status && status !== task.status) {
       const statusMessages = {
-        pending: 'Task moved to pending',
-        in_progress: 'Task started and is now in progress',
-        completed: 'Task completed successfully',
-        on_hold: 'Task put on hold',
-        cancelled: 'Task cancelled'
+        pending: 'Задача перемещена в ожидание',
+        in_progress: 'Задача начата и теперь выполняется',
+        completed: 'Задача успешно завершена',
+        on_hold: 'Задача приостановлена',
+        cancelled: 'Задача отменена'
       } as const;
 
-      const notificationTitle = statusMessages[status as keyof typeof statusMessages] || 'Task status updated';
+      const notificationTitle =
+        statusMessages[status as keyof typeof statusMessages] ||
+        'Статус задачи обновлен';
 
       await NotificationService.createNotification({
         userId: task.clientId,
         title: notificationTitle,
-        message: `Task "${task.title}" status changed from "${task.status}" to "${status}"`,
+        message: `Статус задачи "${task.title}" изменен с "${task.status}" на "${status}"`,
         type: 'task_update',
         relatedId: taskId,
         relatedType: 'task'


### PR DESCRIPTION
## Summary
- localize task status change messages
- keep scripts section unchanged

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_6857cb525eb88320991b8b8555c38d96