### PR TITLE
Fix task status change notification localization

### DIFF
--- a/client/src/components/notifications/NotificationBell.tsx
+++ b/client/src/components/notifications/NotificationBell.tsx
@@ -79,18 +79,31 @@ export const NotificationBell = () => {
     });
   };
   
+  const translateTaskStatus = (status: string) =>
+    t(`notifications.statuses.${status}`, status);
+
   // Функция для перевода содержимого уведомлений
   const translateNotificationContent = (notification: Notification) => {
     // Уведомления о задачах
     if (notification.title === "Task Status Updated" && notification.content.includes("has been updated to")) {
       const taskTitle = notification.content.match(/Task "(.*?)" has been updated to/)?.[1] || "";
       const status = notification.content.match(/updated to (.*?)$/)?.[1] || "";
-      const translatedStatus = t(`task.status.${status}`, status);
+      const translatedStatus = translateTaskStatus(status);
       return t('notifications.taskStatusUpdateContent', {
         title: taskTitle,
         status: translatedStatus
       });
-    } 
+    }
+
+    const statusChangeMatch = notification.content.match(/Task ['"]?(.*?)['"]? status changed from ['"]?(.*?)['"]? to ['"]?(.*?)['"]?$/i);
+    if (statusChangeMatch) {
+      const [, name, oldStatus, newStatus] = statusChangeMatch;
+      return t('notifications.taskStatusChangedContent', {
+        name,
+        oldStatus: translateTaskStatus(oldStatus),
+        newStatus: translateTaskStatus(newStatus)
+      });
+    }
     
     if (notification.title === "Task Completed" && notification.content.includes("has been marked as completed")) {
       const taskTitle = notification.content.match(/Task "(.*?)" has been marked as completed/)?.[1] || "";

--- a/client/src/components/notifications/NotificationList.tsx
+++ b/client/src/components/notifications/NotificationList.tsx
@@ -25,6 +25,22 @@ const NotificationList: React.FC<NotificationListProps> = ({
   onViewAll
 }) => {
   const { t } = useTranslation();
+
+  const translateStatus = (status: string) =>
+    t(`notifications.statuses.${status}`, status);
+
+  const translateContent = (notification: Notification) => {
+    const statusChangeMatch = notification.content.match(/Task ['"]?(.*?)['"]? status changed from ['"]?(.*?)['"]? to ['"]?(.*?)['"]?$/i);
+    if (statusChangeMatch) {
+      const [, name, oldStatus, newStatus] = statusChangeMatch;
+      return t('notifications.taskStatusChangedContent', {
+        name,
+        oldStatus: translateStatus(oldStatus),
+        newStatus: translateStatus(newStatus)
+      });
+    }
+    return notification.content;
+  };
   const getNotificationIcon = (type: string) => {
     switch (type) {
       case 'message':
@@ -79,7 +95,7 @@ const NotificationList: React.FC<NotificationListProps> = ({
                   {getNotificationIcon(notification.relatedType || 'default')}
                 </div>
                 <div>
-                  <p className="text-sm text-neutral-700">{notification.content}</p>
+                  <p className="text-sm text-neutral-700">{translateContent(notification)}</p>
                   <p className="text-xs text-neutral-500 mt-1">{getRelativeTime(notification.createdAt ?? new Date())}</p>
                 </div>
               </div>

--- a/client/src/i18n/locales/en.json
+++ b/client/src/i18n/locales/en.json
@@ -533,7 +533,13 @@
     "scheduleChangedContent": "Schedule has been changed: {{info}}",
     "userProfileUpdatedByAdmin": "Your profile has been updated by an administrator.",
     "adminUpdatedUserProfile": "You have updated user profile for {{name}}.",
-    "adminNotificationUserUpdated": "User profile for {{name}} has been updated."
+    "adminNotificationUserUpdated": "User profile for {{name}} has been updated.",
+    "taskStatusChangedContent": "Task '{{name}}' status changed from '{{oldStatus}}' to '{{newStatus}}'",
+    "statuses": {
+      "completed": "completed",
+      "in_progress": "in progress",
+      "new": "new"
+    }
   },
   "settings": {
     "title": "Settings",

--- a/client/src/i18n/locales/ru.json
+++ b/client/src/i18n/locales/ru.json
@@ -581,7 +581,13 @@
     "scheduleChangedContent": "Изменения в расписании: {{info}}",
     "userProfileUpdatedByAdmin": "Ваш профиль был обновлён администратором.",
     "adminUpdatedUserProfile": "Вы обновили профиль пользователя {{name}}.",
-  "adminNotificationUserUpdated": "Профиль пользователя {{name}} был обновлён."
+    "adminNotificationUserUpdated": "Профиль пользователя {{name}} был обновлён.",
+    "taskStatusChangedContent": "Статус задачи '{{name}}' изменен с '{{oldStatus}}' на '{{newStatus}}'",
+    "statuses": {
+      "completed": "завершена",
+      "in_progress": "выполняется",
+      "new": "новая"
+    }
   },
   "roles": {
     "admin": "Администратор",


### PR DESCRIPTION
## Summary
- localize task status change messages
- translate English status names to Russian
- show translated text in notification components

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6857ccee5674832097f42fc825da3326