### PR TITLE
Sync status labels in notifications

### DIFF
--- a/client/src/components/notifications/NotificationBell.tsx
+++ b/client/src/components/notifications/NotificationBell.tsx
@@ -13,6 +13,7 @@ import { Button } from '@/components/ui/button';
 import { apiRequest } from '@/lib/queryClient';
 import { formatDistanceToNow } from 'date-fns';
 import { ru, enUS } from 'date-fns/locale';
+import { getTaskStatusLabel } from '@/lib/taskStatus';
 import { ScrollArea } from '@/components/ui/scroll-area';
 
 // Определение типа для уведомлений
@@ -80,7 +81,7 @@ export const NotificationBell = () => {
   };
   
   const translateTaskStatus = (status: string) =>
-    t(`notifications.statuses.${status}`, status);
+    getTaskStatusLabel(status, t);
 
   // Функция для перевода содержимого уведомлений
   const translateNotificationContent = (notification: Notification) => {

--- a/client/src/components/notifications/NotificationList.tsx
+++ b/client/src/components/notifications/NotificationList.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Notification } from '@shared/schema';
 import { getRelativeTime } from '@/lib/utils';
+import { getTaskStatusLabel } from '@/lib/taskStatus';
 import { 
   Bell, 
   MessageSquare, 
@@ -27,7 +28,7 @@ const NotificationList: React.FC<NotificationListProps> = ({
   const { t } = useTranslation();
 
   const translateStatus = (status: string) =>
-    t(`notifications.statuses.${status}`, status);
+    getTaskStatusLabel(status, t);
 
   const translateContent = (notification: Notification) => {
     const statusChangeMatch = notification.content.match(/Task ['"]?(.*?)['"]? status changed from ['"]?(.*?)['"]? to ['"]?(.*?)['"]?$/i);

--- a/client/src/components/students/StudentTaskItem.tsx
+++ b/client/src/components/students/StudentTaskItem.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { getTaskStatusLabel } from '@/lib/taskStatus';
 import { format } from 'date-fns';
 import { ru } from 'date-fns/locale';
 import { Card } from '@/components/ui/card';
@@ -34,18 +35,7 @@ const StudentTaskItem: React.FC<StudentTaskItemProps> = ({
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   // Получение статуса задачи в виде текста
-  const getStatusText = (status: string) => {
-    switch (status) {
-      case 'in_progress': 
-        return t('task.status.inProgress', 'В процессе');
-      case 'completed': 
-        return t('task.status.completed', 'Выполнено');
-      case 'on_hold': 
-        return t('task.status.onHold', 'На паузе');
-      default: 
-        return t('task.status.new', 'Новая');
-    }
-  };
+  const getStatusText = (status: string) => getTaskStatusLabel(status, t);
 
   // Получение цвета для статуса
   const getStatusColor = (status: string) => {

--- a/client/src/components/users/StudentCard.tsx
+++ b/client/src/components/users/StudentCard.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { format } from 'date-fns';
 import { ru } from 'date-fns/locale';
+import { getTaskStatusLabel } from '@/lib/taskStatus';
 import { useQuery } from '@tanstack/react-query';
 import { UserData } from './UserCard';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -369,10 +370,7 @@ const StudentCard: React.FC<StudentCardProps> = ({
                             'bg-green-50 text-green-600 border-green-200 dark:bg-green-950/50 dark:text-green-400 dark:border-green-800'
                           }
                         >
-                          {task.status === 'new' ? t('task.status.new', 'Новая') :
-                           task.status === 'in_progress' ? t('task.status.inProgress', 'В процессе') :
-                           task.status === 'on_hold' ? t('task.status.onHold', 'На паузе') :
-                           t('task.status.completed', 'Выполнено')}
+                          {getTaskStatusLabel(task.status, t)}
                         </Badge>
                       </div>
                       {task.description && (

--- a/client/src/i18n/locales/en.json
+++ b/client/src/i18n/locales/en.json
@@ -536,9 +536,10 @@
     "adminNotificationUserUpdated": "User profile for {{name}} has been updated.",
     "taskStatusChangedContent": "Task '{{name}}' status changed from '{{oldStatus}}' to '{{newStatus}}'",
     "statuses": {
-      "completed": "completed",
-      "in_progress": "in progress",
-      "new": "new"
+      "completed": "Completed",
+      "in_progress": "In Progress",
+      "new": "New",
+      "on_hold": "On Hold"
     }
   },
   "settings": {

--- a/client/src/i18n/locales/ru.json
+++ b/client/src/i18n/locales/ru.json
@@ -584,9 +584,10 @@
     "adminNotificationUserUpdated": "Профиль пользователя {{name}} был обновлён.",
     "taskStatusChangedContent": "Статус задачи '{{name}}' изменен с '{{oldStatus}}' на '{{newStatus}}'",
     "statuses": {
-      "completed": "завершена",
-      "in_progress": "выполняется",
-      "new": "новая"
+      "completed": "Завершена",
+      "in_progress": "В работе",
+      "new": "Новая",
+      "on_hold": "Приостановлена"
     }
   },
   "roles": {

--- a/client/src/lib/taskStatus.ts
+++ b/client/src/lib/taskStatus.ts
@@ -1,0 +1,13 @@
+import { TFunction } from 'i18next';
+
+export type TaskStatus = 'new' | 'in_progress' | 'completed' | 'on_hold';
+
+export function getTaskStatusLabel(status: string, t: TFunction): string {
+  const map: Record<string, string> = {
+    new: t('task.status.new', 'Новая'),
+    in_progress: t('task.status.in_progress', 'В работе'),
+    completed: t('task.status.completed', 'Завершена'),
+    on_hold: t('task.status.on_hold', 'Приостановлена'),
+  };
+  return map[status] ?? status;
+}


### PR DESCRIPTION
## Summary
- centralize task status translation mapping
- update notification components to use shared status labels
- harmonize task status labels in Student views
- align notification locale files with UI

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_6857d02544fc83208e46aa3e7497a1da