### PR TITLE
Add shared task status helper

### DIFF
--- a/client/src/lib/taskStatus.ts
+++ b/client/src/lib/taskStatus.ts
@@ -1,13 +1,9 @@
 import { TFunction } from 'i18next';
+import { getTaskStatusLabel as baseStatusLabel } from '@shared/utils';
 
 export type TaskStatus = 'new' | 'in_progress' | 'completed' | 'on_hold';
 
 export function getTaskStatusLabel(status: string, t: TFunction): string {
-  const map: Record<string, string> = {
-    new: t('task.status.new', 'Новая'),
-    in_progress: t('task.status.in_progress', 'В работе'),
-    completed: t('task.status.completed', 'Завершена'),
-    on_hold: t('task.status.on_hold', 'Приостановлена'),
-  };
-  return map[status] ?? status;
+  const fallback = baseStatusLabel(status);
+  return t(`task.status.${status}`, fallback);
 }

--- a/server/routes/tasks.ts
+++ b/server/routes/tasks.ts
@@ -6,6 +6,7 @@ import type { RouteContext } from "./index";
 import { logger } from "../utils/logger";
 import { getDbUserBySupabaseUser } from "../utils/userMapping";
 import { NotificationService } from "../services/NotificationService";
+import { getTaskStatusLabel } from '@shared/utils';
 
 export function registerTaskRoutes(app: Express, { authenticateUser, requireRole }: RouteContext) {
 // Tasks Routes
@@ -363,7 +364,7 @@ app.put('/api/tasks/:id', authenticateUser, async (req, res) => {
       await NotificationService.createNotification({
         userId: task.clientId,
         title: notificationTitle,
-        message: `Статус задачи "${task.title}" изменен с "${task.status}" на "${taskData.status}"`,
+        message: `Статус задачи "${task.title}" изменен с "${getTaskStatusLabel(task.status)}" на "${getTaskStatusLabel(taskData.status)}"`,
         type: 'task_update',
         relatedId: taskId,
         relatedType: 'task'
@@ -532,7 +533,7 @@ app.patch('/api/tasks/:id/status', authenticateUser, async (req, res) => {
       await NotificationService.createNotification({
         userId: task.clientId,
         title: notificationTitle,
-        message: `Статус задачи "${task.title}" изменен с "${task.status}" на "${status}"`,
+        message: `Статус задачи "${task.title}" изменен с "${getTaskStatusLabel(task.status)}" на "${getTaskStatusLabel(status)}"`,
         type: 'task_update',
         relatedId: taskId,
         relatedType: 'task'

--- a/shared/utils.ts
+++ b/shared/utils.ts
@@ -1,0 +1,11 @@
+export type TaskStatus = 'new' | 'in_progress' | 'completed' | 'on_hold';
+
+export function getTaskStatusLabel(status: string): string {
+  const map: Record<string, string> = {
+    new: 'Новая',
+    in_progress: 'В работе',
+    completed: 'Завершена',
+    on_hold: 'Приостановлена',
+  };
+  return map[status] ?? status;
+}


### PR DESCRIPTION
## Summary
- centralize status-to-label mapping in `shared/utils.ts`
- use the shared helper in the client task status util
- translate task status names in task update notifications

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_6857d3554654832082f17b64a08c4174