### PR TITLE
Increase button & input touch sizes

### DIFF
--- a/client/src/components/curriculum/CurriculumPlanTable.tsx
+++ b/client/src/components/curriculum/CurriculumPlanTable.tsx
@@ -1328,9 +1328,8 @@ export const CurriculumPlanTable = React.forwardRef<
               Выбрано элементов: {selectedNodes.size}
             </span>
             {/* Кнопка "Удалить выбранное" удалена, так как она дублирует функциональность */}
-            <Button 
-              variant="outline" 
-              size="sm"
+            <Button
+              variant="outline"
               onClick={() => clearSelection()}
             >
               <X size={16} className="mr-2" />

--- a/client/src/components/dashboards/ErrorAlert.tsx
+++ b/client/src/components/dashboards/ErrorAlert.tsx
@@ -20,7 +20,7 @@ export default function ErrorAlert({ error, onRetry }: ErrorAlertProps) {
           <AlertDescription>{message}</AlertDescription>
         </div>
       </div>
-      <Button size="sm" onClick={onRetry}>{t('common.actions.retry', 'Повторить')}</Button>
+      <Button onClick={onRetry}>{t('common.actions.retry', 'Повторить')}</Button>
     </Alert>
   );
 }

--- a/client/src/components/dashboards/TeacherDashboard.tsx
+++ b/client/src/components/dashboards/TeacherDashboard.tsx
@@ -241,7 +241,7 @@ const TeacherDashboard = () => {
               )}
             </CardContent>
             <CardFooter>
-              <Button variant="outline" size="sm" asChild>
+              <Button variant="outline" asChild>
                 <Link href="/schedule">
                   {t('schedule.viewFull', 'Просмотреть полное расписание')}
                 </Link>
@@ -304,12 +304,12 @@ const TeacherDashboard = () => {
               )}
             </CardContent>
             <CardFooter className="flex justify-between">
-              <Button variant="outline" size="sm" asChild>
+              <Button variant="outline" asChild>
                 <Link href="/assignments">
                   {t('assignments.viewAll', 'Все задания')}
                 </Link>
               </Button>
-              <Button size="sm" asChild>
+              <Button asChild>
                 <Link href="/assignments/new">
                   <PlusCircle className="h-4 w-4 mr-2" />
                   {t('dashboard.teacher.assignNewTask', 'Назначить задание')}
@@ -348,7 +348,7 @@ const TeacherDashboard = () => {
                           </p>
                         </div>
                       </div>
-                      <Button variant="ghost" size="sm" asChild>
+                      <Button variant="ghost" asChild>
                         <Link href={`/chat/${student.id}`}>
                           <MessageSquare className="h-4 w-4 mr-1" />
                           {t('chat.contact', 'Связаться')}
@@ -423,7 +423,7 @@ const TeacherDashboard = () => {
             </CardContent>
             <CardFooter>
               {/*
-              <Button variant="outline" size="sm" asChild className="w-full">
+              <Button variant="outline" asChild className="w-full">
                 <Link href="/requests">
                   {t('requests.viewAll', 'Просмотреть все заявки')}
                 </Link>

--- a/client/src/components/layout/navbar.tsx
+++ b/client/src/components/layout/navbar.tsx
@@ -145,16 +145,14 @@ export function Navbar() {
                         {t('settings.language')}
                       </div>
                       <div className="flex gap-2">
-                        <Button 
-                          variant={i18n.resolvedLanguage === 'ru' ? 'default' : 'outline'} 
-                          size="sm"
+                        <Button
+                          variant={i18n.resolvedLanguage === 'ru' ? 'default' : 'outline'}
                           onClick={() => i18n.changeLanguage('ru')}
                         >
                           {t('settings.languages.ru')}
                         </Button>
-                        <Button 
-                          variant={i18n.resolvedLanguage === 'en' ? 'default' : 'outline'} 
-                          size="sm"
+                        <Button
+                          variant={i18n.resolvedLanguage === 'en' ? 'default' : 'outline'}
                           onClick={() => i18n.changeLanguage('en')}
                         >
                           {t('settings.languages.en')}

--- a/client/src/components/notifications/NotificationBell.tsx
+++ b/client/src/components/notifications/NotificationBell.tsx
@@ -266,7 +266,6 @@ export const NotificationBell = () => {
           {unreadCount > 0 && (
             <Button
               variant="ghost"
-              size="sm"
               onClick={markAllAsRead}
               className="text-xs text-sidebar-foreground/80 hover:text-sidebar-foreground p-1 px-2 rounded-md hover:bg-sidebar-accent/10 border-none outline-none"
             >
@@ -329,7 +328,6 @@ export const NotificationBell = () => {
                     {!notification.isRead && (
                       <Button
                         variant="ghost"
-                        size="sm"
                         onClick={(e) => {
                           e.stopPropagation(); // Предотвращаем всплытие события клика
                           markAsRead(notification.id);

--- a/client/src/components/students/StudentCard.tsx
+++ b/client/src/components/students/StudentCard.tsx
@@ -153,7 +153,7 @@ const StudentCard: React.FC<StudentCardProps> = ({ student, onClick }) => {
             {student.note && (
               <Popover>
                 <PopoverTrigger asChild>
-                  <Button variant="ghost" size="icon" className="h-8 w-8 text-amber-500">
+                  <Button variant="ghost" size="icon" className="h-11 w-11 text-amber-500">
                     <Bookmark size={16} />
                   </Button>
                 </PopoverTrigger>
@@ -293,11 +293,11 @@ const StudentCard: React.FC<StudentCardProps> = ({ student, onClick }) => {
         </CardContent>
 
         <CardFooter className="pt-2 flex justify-between">
-          <Button variant="outline" size="sm" onClick={handleClick}>
+          <Button variant="outline" onClick={handleClick}>
             <Info className="mr-2 h-4 w-4" />
             {t('actions.details', 'Подробнее')}
           </Button>
-          <Button variant="ghost" size="sm" onClick={handleEditClick}>
+          <Button variant="ghost" onClick={handleEditClick}>
             <Edit className="mr-2 h-4 w-4" />
             {t('actions.edit', 'Редактировать')}
           </Button>

--- a/client/src/components/students/StudentDocuments.tsx
+++ b/client/src/components/students/StudentDocuments.tsx
@@ -72,7 +72,7 @@ const StudentDocuments: React.FC<StudentDocumentsProps> = ({ userId, documents, 
         </p>
         {/* Заглушка для будущей функциональности загрузки */}
         {/*
-        <Button variant="outline" size="sm" className="mt-4">
+        <Button variant="outline" className="mt-4">
           <Upload className="mr-2 h-4 w-4" />
           {t('documents.upload', 'Загрузить файл')}
         </Button>
@@ -97,7 +97,7 @@ const StudentDocuments: React.FC<StudentDocumentsProps> = ({ userId, documents, 
           </div>
           
           {doc.fileUrl && (
-            <Button variant="ghost" size="sm" asChild>
+            <Button variant="ghost" asChild>
               <a href={doc.fileUrl} download target="_blank" rel="noopener noreferrer">
                 <Download className="h-4 w-4" />
               </a>

--- a/client/src/components/tasks/TaskCard.tsx
+++ b/client/src/components/tasks/TaskCard.tsx
@@ -121,14 +121,14 @@ const TaskCard = ({ task, onStatusChange, onEditClick, onDeleteClick, onViewDeta
           )}
           {(isCreator || isAdmin) && (
             <>
-              <Button variant="outline" size="sm" className="flex-shrink-0 h-10" title={t('task.edit_task')} onClick={() => onEditClick && onEditClick(task)}>
+              <Button variant="outline" className="flex-shrink-0 h-11" title={t('task.edit_task')} onClick={() => onEditClick && onEditClick(task)}>
                 <span className="sr-only">{t('task.edit_task')}</span>
                 <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                   <path d="M12 20h9"></path>
                   <path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z"></path>
                 </svg>
               </Button>
-              <Button variant="destructive" size="sm" className="flex-shrink-0 h-10" title={t('task.delete_task')} onClick={() => onDeleteClick && onDeleteClick(task)}>
+              <Button variant="destructive" className="flex-shrink-0 h-11" title={t('task.delete_task')} onClick={() => onDeleteClick && onDeleteClick(task)}>
                 <span className="sr-only">{t('task.delete_task')}</span>
                 <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                   <path d="M3 6h18"></path>

--- a/client/src/components/ui/button.tsx
+++ b/client/src/components/ui/button.tsx
@@ -21,10 +21,10 @@ const buttonVariants = cva(
         danger: "bg-red-600 text-white hover:bg-red-700 focus:ring-red-500",
       },
       size: {
-        default: "h-10 px-4 py-2",
-        sm: "h-9 rounded-md px-3",
+        default: "h-11 px-4 py-2",
+        sm: "h-11 rounded-md px-3",
         lg: "h-11 rounded-md px-8",
-        icon: "h-10 w-10",
+        icon: "h-11 w-11",
       },
     },
     defaultVariants: {

--- a/client/src/components/ui/input.tsx
+++ b/client/src/components/ui/input.tsx
@@ -11,7 +11,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          "flex h-11 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
           className
         )}
         ref={ref}

--- a/client/src/components/ui/sidebar.tsx
+++ b/client/src/components/ui/sidebar.tsx
@@ -270,7 +270,7 @@ const SidebarTrigger = React.forwardRef<
       data-sidebar="trigger"
       variant="ghost"
       size="icon"
-      className={cn("h-7 w-7", className)}
+      className={cn("h-11 w-11", className)}
       onClick={(event) => {
         onClick?.(event)
         toggleSidebar()

--- a/client/src/components/users/StudentCard.tsx
+++ b/client/src/components/users/StudentCard.tsx
@@ -195,10 +195,9 @@ const StudentCard: React.FC<StudentCardProps> = ({
             
             {/* Кнопка редактирования (только для админов/директоров) */}
             {canEdit && (
-              <Button 
-                size="sm" 
-                variant="outline" 
-                className="h-8" 
+              <Button
+                variant="outline"
+                className="h-11"
                 onClick={handleEdit}
               >
                 <Edit className="h-4 w-4 mr-1" />
@@ -382,7 +381,7 @@ const StudentCard: React.FC<StudentCardProps> = ({
                   ))}
                   
                   {activeTasks.length > 3 && (
-                    <Button variant="ghost" size="sm" className="w-full mt-2">
+                    <Button variant="ghost" className="w-full mt-2">
                       <span>{t('task.viewAll', 'Показать все')} ({activeTasks.length})</span>
                       <ChevronRight className="h-4 w-4 ml-1" />
                     </Button>
@@ -415,7 +414,7 @@ const StudentCard: React.FC<StudentCardProps> = ({
                           </p>
                         </div>
                       </div>
-                      <Button variant="ghost" size="sm">
+                      <Button variant="ghost">
                         {t('common.download', 'Скачать')}
                       </Button>
                     </div>

--- a/client/src/components/users/TeacherCard.tsx
+++ b/client/src/components/users/TeacherCard.tsx
@@ -140,10 +140,9 @@ const TeacherCard: React.FC<TeacherCardProps> = ({ teacher, onClick, onEdit }) =
             
             {/* Кнопка редактирования (только для админов/директоров) */}
             {canEdit && (
-              <Button 
-                size="sm" 
-                variant="outline" 
-                className="h-8" 
+              <Button
+                variant="outline"
+                className="h-11"
                 onClick={handleEdit}
               >
                 <Edit className="h-4 w-4 mr-1" />

--- a/client/src/pages/curriculum/CurriculumPlans.tsx
+++ b/client/src/pages/curriculum/CurriculumPlans.tsx
@@ -290,7 +290,6 @@ export default function CurriculumPlans() {
                   <CardFooter className="pt-4 flex justify-between">
                     <Button
                       variant="outline"
-                      size="sm"
                       onClick={(e) => {
                         e.stopPropagation(); // Предотвращаем всплытие события
                         navigate(`/curriculum-plans/${plan.id}/edit`);
@@ -301,7 +300,6 @@ export default function CurriculumPlans() {
                     </Button>
                     <Button
                       variant="destructive"
-                      size="sm"
                       onClick={(e) => {
                         e.stopPropagation(); // Предотвращаем всплытие события
                         handleDeleteClick(plan);

--- a/client/src/pages/documents/DocumentPage.tsx
+++ b/client/src/pages/documents/DocumentPage.tsx
@@ -233,7 +233,7 @@ export default function DocumentPage({ documentType, title, icon: Icon }: Docume
                     )}
                   </CardContent>
                   <CardFooter className="flex justify-end">
-                    <Button variant="outline" size="sm" asChild>
+                    <Button variant="outline" asChild>
                       <a href={document.fileUrl || '#'} target="_blank" rel="noopener noreferrer">
                         <DownloadCloud className="h-4 w-4 mr-2" />
                         Download

--- a/client/src/pages/schedule/Schedule.tsx
+++ b/client/src/pages/schedule/Schedule.tsx
@@ -214,7 +214,6 @@ export default function Schedule() {
             <div className="flex items-center gap-2">
               <Button
                 variant="outline"
-                size="sm"
                 onClick={() => navigatePeriod('prev')}
                 disabled={viewPeriod === 'all'}
               >
@@ -240,7 +239,6 @@ export default function Schedule() {
 
               <Button
                 variant="outline"
-                size="sm"
                 onClick={() => navigatePeriod('next')}
                 disabled={viewPeriod === 'all'}
               >

--- a/client/src/pages/tasks/Tasks.tsx
+++ b/client/src/pages/tasks/Tasks.tsx
@@ -154,14 +154,12 @@ const TasksPage = () => {
         <div className="flex flex-wrap gap-2">
           <Button
             variant={statusFilter === null ? "default" : "outline"}
-            size="sm"
             onClick={() => setStatusFilter(null)}
           >
             {t('task.all')}
           </Button>
           <Button
             variant={statusFilter === 'new' ? "default" : "outline"}
-            size="sm"
             onClick={() => setStatusFilter('new')}
             className="flex items-center gap-2"
           >
@@ -170,7 +168,6 @@ const TasksPage = () => {
           </Button>
           <Button
             variant={statusFilter === 'in_progress' ? "default" : "outline"}
-            size="sm"
             onClick={() => setStatusFilter('in_progress')}
             className="flex items-center gap-2"
           >
@@ -179,7 +176,6 @@ const TasksPage = () => {
           </Button>
           <Button
             variant={statusFilter === 'completed' ? "default" : "outline"}
-            size="sm"
             onClick={() => setStatusFilter('completed')}
             className="flex items-center gap-2"
           >
@@ -188,7 +184,6 @@ const TasksPage = () => {
           </Button>
           <Button
             variant={statusFilter === 'on_hold' ? "default" : "outline"}
-            size="sm"
             onClick={() => setStatusFilter('on_hold')}
             className="flex items-center gap-2"
           >

--- a/client/src/pages/users/Users.tsx
+++ b/client/src/pages/users/Users.tsx
@@ -506,7 +506,6 @@ export default function Users() {
                       <TableCell className="text-right space-x-2">
                         <Button
                           variant="outline"
-                          size="sm"
                           onClick={(e) => {
                             e.stopPropagation(); // Предотвращаем всплытие клика на строку
                             openEditDialog(user);
@@ -516,7 +515,6 @@ export default function Users() {
                         </Button>
                         <Button
                           variant="outline"
-                          size="sm"
                           onClick={(e) => {
                             e.stopPropagation(); // Предотвращаем всплытие клика на строку
                             setUserToDelete(user);


### PR DESCRIPTION
## Summary
- bump default button height to 44px
- enlarge input field height to 44px
- remove `size="sm"` usage across components
- ensure icon buttons meet minimum size

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6857fa9860d483208808631140ad779d