### PR TITLE
Enhance mobile table responsiveness

### DIFF
--- a/client/src/components/curriculum/AcademicCalendarTable.tsx
+++ b/client/src/components/curriculum/AcademicCalendarTable.tsx
@@ -753,7 +753,7 @@ export function AcademicCalendarTable({
       </div>
 
       <div className="rounded-md overflow-hidden border shadow-sm dark:border-slate-700">
-        <div className="overflow-auto max-h-[500px] custom-scrollbar calendar-wrapper" ref={scrollWrapperRef}>
+        <div className="table-responsive overflow-auto max-h-[500px] custom-scrollbar calendar-wrapper" ref={scrollWrapperRef}>
           <div className="min-w-max relative">
             <table className="w-full border-collapse" ref={tableRef}>
               <thead ref={headerRef}>

--- a/client/src/components/curriculum/CurriculumPlanTable.tsx
+++ b/client/src/components/curriculum/CurriculumPlanTable.tsx
@@ -1347,7 +1347,7 @@ export const CurriculumPlanTable = React.forwardRef<
 
       >
         <div className="relative bg-white dark:bg-slate-900 shadow-md rounded-lg overflow-hidden">
-          <div className="overflow-x-auto overflow-y-auto max-h-[80vh]">
+          <div className="table-responsive overflow-x-auto overflow-y-auto max-h-[80vh]">
             <table className="w-full text-sm text-left border-collapse">
               <thead className="sticky top-0 z-20">
                 {/* Первый уровень заголовка: Дисциплины и курсы */}

--- a/client/src/components/curriculum/SummaryTable.tsx
+++ b/client/src/components/curriculum/SummaryTable.tsx
@@ -42,7 +42,8 @@ export const SummaryTable: React.FC<{ summary: SummaryRow[]; courses: number }> 
   }, [data, courses]);
   
   return (
-    <table className="summary-table w-full border-collapse text-sm">
+    <div className="table-responsive">
+      <table className="summary-table w-full border-collapse text-sm">
       <thead>
         <tr>
           <th rowSpan={2} className="sticky left-0 z-10 bg-slate-800 text-white px-3 py-1">Вид</th>
@@ -115,6 +116,7 @@ export const SummaryTable: React.FC<{ summary: SummaryRow[]; courses: number }> 
           <td className="text-center font-bold bg-slate-200 dark:bg-slate-600/40">{weeksPerSemester.total}</td>
         </tr>
       </tbody>
-    </table>
+      </table>
+    </div>
   );
 };

--- a/client/src/components/tasks/TaskCard.tsx
+++ b/client/src/components/tasks/TaskCard.tsx
@@ -54,17 +54,17 @@ const TaskCard = ({ task, onStatusChange, onEditClick, onDeleteClick, onViewDeta
         </div>
       </CardHeader>
       <CardContent className="flex-grow">
-        <p className="text-sm mb-3 line-clamp-3" title={task.description || t('task.no_description')}>
+        <p className="text-sm mb-3 line-clamp-3 hide-md" title={task.description || t('task.no_description')}>
           {task.description || t('task.no_description')}
         </p>
         <div className="space-y-2 text-sm">
-          <div className="flex items-center justify-between text-muted-foreground">
+          <div className="flex items-center justify-between text-muted-foreground hide-sm">
             <span>{t('task.client')}:</span>
             <span className="font-medium text-foreground">
               {task.client ? `${task.client.firstName} ${task.client.lastName}` : t('task.not_assigned')}
             </span>
           </div>
-          <div className="flex items-center justify-between text-muted-foreground">
+          <div className="flex items-center justify-between text-muted-foreground hide-sm">
             <span>{t('task.executor')}:</span>
             <span className="font-medium text-foreground">
               {task.executor ? `${task.executor.firstName} ${task.executor.lastName}` : t('task.not_assigned')}

--- a/client/src/components/ui/table.tsx
+++ b/client/src/components/ui/table.tsx
@@ -6,7 +6,7 @@ const Table = React.forwardRef<
   HTMLTableElement,
   React.HTMLAttributes<HTMLTableElement>
 >(({ className, ...props }, ref) => (
-  <div className="relative w-full overflow-auto">
+  <div className="table-responsive w-full">
     <table
       ref={ref}
       className={cn("w-full caption-bottom text-sm", className)}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -990,3 +990,45 @@ tfoot {
 .dark .summary-table td {
   border-color: rgba(100, 116, 139, 0.3);
 }
+
+/* Responsive table helpers */
+@media (max-width: 1024px) {
+  .hide-lg {
+    display: none;
+  }
+}
+
+@media (max-width: 768px) {
+  .hide-md {
+    display: none;
+  }
+}
+
+@media (max-width: 480px) {
+  .hide-sm {
+    display: none;
+  }
+}
+
+.table-responsive {
+  position: relative;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  scroll-behavior: smooth;
+}
+
+.table-responsive::-webkit-scrollbar {
+  height: 6px;
+}
+
+.table-responsive::-webkit-scrollbar-thumb {
+  background-color: rgba(100, 116, 139, 0.4);
+  border-radius: 3px;
+}
+
+.table-responsive table th:first-child,
+.table-responsive table td:first-child {
+  position: sticky;
+  left: 0;
+  background-color: inherit;
+}

--- a/client/src/pages/schedule/Schedule.tsx
+++ b/client/src/pages/schedule/Schedule.tsx
@@ -125,12 +125,13 @@ export default function Schedule() {
               </CardDescription>
             </CardHeader>
             <CardContent>
+              <div className="table-responsive">
               <Table>
                 <TableHeader>
                   <TableRow>
                     <TableHead>Предмет</TableHead>
                     <TableHead>Время</TableHead>
-                    <TableHead>Кабинет</TableHead>
+                    <TableHead className="hide-md">Кабинет</TableHead>
                     <TableHead>Преподаватель</TableHead>
                   </TableRow>
                 </TableHeader>
@@ -146,7 +147,7 @@ export default function Schedule() {
                           {formatTime(item.startTime)} - {formatTime(item.endTime)}
                         </div>
                       </TableCell>
-                      <TableCell>
+                      <TableCell className="hide-md">
                         <div className="flex items-center gap-1">
                           <MapPin className="h-4 w-4 text-muted-foreground" />
                           {item.roomNumber || 'Не назначен'}
@@ -165,6 +166,7 @@ export default function Schedule() {
                   ))}
                 </TableBody>
               </Table>
+              </div>
             </CardContent>
           </Card>
         ))}

--- a/client/src/pages/users/Users.tsx
+++ b/client/src/pages/users/Users.tsx
@@ -463,15 +463,15 @@ export default function Users() {
               <p>No users found matching your criteria.</p>
             </div>
           ) : (
-            <div className="rounded-md border">
+            <div className="rounded-md border table-responsive">
               <Table>
                 <TableCaption>A list of all users in the system.</TableCaption>
                 <TableHeader>
                   <TableRow>
                     <TableHead>Name</TableHead>
-                    <TableHead>Email</TableHead>
+                    <TableHead className="hide-lg">Email</TableHead>
                     <TableHead>Role</TableHead>
-                    <TableHead>Created</TableHead>
+                    <TableHead className="hide-md">Created</TableHead>
                     <TableHead className="text-right">Actions</TableHead>
                   </TableRow>
                 </TableHeader>
@@ -488,7 +488,7 @@ export default function Users() {
                       <TableCell className="font-medium">
                         {user.firstName} {user.lastName}
                       </TableCell>
-                      <TableCell>{user.email}</TableCell>
+                      <TableCell className="hide-lg">{user.email}</TableCell>
                       <TableCell>
                         <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
                           user.role === 'director'
@@ -502,7 +502,7 @@ export default function Users() {
                           {user.role.charAt(0).toUpperCase() + user.role.slice(1)}
                         </span>
                       </TableCell>
-                      <TableCell>{formatDate(user.createdAt)}</TableCell>
+                      <TableCell className="hide-md">{formatDate(user.createdAt)}</TableCell>
                       <TableCell className="text-right space-x-2">
                         <Button
                           variant="outline"


### PR DESCRIPTION
## Summary
- add helper classes and responsive table wrapper
- hide non-essential columns on small screens in user and schedule tables
- improve mobile view of task cards
- make curriculum tables use table-responsive wrapper

## Testing
- `npm test` *(fails: Missing script and network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6857fe4991dc8320a56043618e85202d