### PR TITLE
Add accessible modal descriptions

### DIFF
--- a/client/src/components/curriculum/CurriculumPlanTable.tsx
+++ b/client/src/components/curriculum/CurriculumPlanTable.tsx
@@ -20,7 +20,8 @@ import {
 import { CSS } from '@dnd-kit/utilities';
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Button } from "@/components/ui/button";
-import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/dialog";
+import { useTranslation } from 'react-i18next';
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
@@ -495,6 +496,7 @@ export const CurriculumPlanTable = React.forwardRef<
   Props
 >(function CurriculumPlanTable(props, ref) {
   const { courses, extraMonths, initialData, onPlanChange, onDirtyChange } = props;
+  const { t } = useTranslation();
   // Состояние для времени последнего изменения (для debounce)
   const lastChangeTime = useRef<number>(0);
   // Идентификатор таймера автосохранения
@@ -1562,6 +1564,7 @@ export const CurriculumPlanTable = React.forwardRef<
         <DialogContent className="sm:max-w-[425px]">
           <DialogHeader>
             <DialogTitle>Редактирование названия</DialogTitle>
+            <DialogDescription>{t('modals.edit_name_description')}</DialogDescription>
           </DialogHeader>
           <div className="grid gap-4 py-4">
             <div className="grid grid-cols-4 items-center gap-4">

--- a/client/src/components/students/EditStudentProfileModal.tsx
+++ b/client/src/components/students/EditStudentProfileModal.tsx
@@ -13,6 +13,7 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
+  DialogDescription,
   DialogFooter,
 } from '@/components/ui/dialog';
 import {
@@ -118,6 +119,7 @@ const EditStudentProfileModal: React.FC<EditStudentProfileModalProps> = ({
       <DialogContent className="sm:max-w-[500px]">
         <DialogHeader>
           <DialogTitle>{t('student.edit.title', 'Редактирование профиля студента')}</DialogTitle>
+          <DialogDescription>{t('modals.edit_profile_description')}</DialogDescription>
         </DialogHeader>
         
         <Form {...form}>

--- a/client/src/components/tasks/TaskDetailsModal.tsx
+++ b/client/src/components/tasks/TaskDetailsModal.tsx
@@ -5,7 +5,7 @@ import { format } from 'date-fns';
 import { ru } from 'date-fns/locale';
 import { Button } from '@/components/ui/button';
 import { StatusBadge, PriorityBadge } from './TaskBadges';
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter, DialogDescription } from '@/components/ui/dialog';
 import { apiRequest } from '@/lib/queryClient';
 import { useToast } from '@/hooks/use-toast';
 import { useAuth } from '@/hooks/use-auth';
@@ -127,6 +127,9 @@ const TaskDetailsModal: React.FC<TaskDetailsModalProps> = ({
           <DialogTitle className="text-xl">
             {task.title}
           </DialogTitle>
+          <DialogDescription>
+            {t('modals.task_details_description')}
+          </DialogDescription>
           <div className="flex flex-wrap gap-2 mt-2">
             {task.priority && <PriorityBadge priority={task.priority} />}
             <StatusBadge status={task.status} />

--- a/client/src/components/ui/command.tsx
+++ b/client/src/components/ui/command.tsx
@@ -4,7 +4,8 @@ import { Command as CommandPrimitive } from "cmdk"
 import { Search } from "lucide-react"
 
 import { cn } from "@/lib/utils"
-import { Dialog, DialogContent } from "@/components/ui/dialog"
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { useTranslation } from "react-i18next"
 
 const Command = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive>,
@@ -24,9 +25,15 @@ Command.displayName = CommandPrimitive.displayName
 interface CommandDialogProps extends DialogProps {}
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
+  const { t } = useTranslation()
+
   return (
     <Dialog {...props}>
       <DialogContent className="overflow-hidden p-0 shadow-lg">
+        <DialogHeader className="sr-only">
+          <DialogTitle>Command Palette</DialogTitle>
+          <DialogDescription>{t('modals.command_dialog_description')}</DialogDescription>
+        </DialogHeader>
         <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
           {children}
         </Command>

--- a/client/src/components/users/EditUserProfileModal.tsx
+++ b/client/src/components/users/EditUserProfileModal.tsx
@@ -13,6 +13,7 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
+  DialogDescription,
   DialogFooter,
 } from '@/components/ui/dialog';
 import {
@@ -279,6 +280,7 @@ const EditUserProfileModal: React.FC<EditUserProfileModalProps> = ({
           <DialogTitle>
             {t('user.edit.title', 'Редактирование профиля')} - {getRoleTitle(user.role)}
           </DialogTitle>
+          <DialogDescription>{t('modals.edit_profile_description')}</DialogDescription>
         </DialogHeader>
         
         <Form {...form}>

--- a/client/src/i18n/locales/en.json
+++ b/client/src/i18n/locales/en.json
@@ -658,7 +658,15 @@
     "goBack": "Go back",
     "goHome": "Go home",
     "contactSupport": "Contact support",
-  "pageMissingHint": "Did you forget to add the page to the router?"
+    "pageMissingHint": "Did you forget to add the page to the router?"
+  },
+  "modals": {
+    "edit_profile_description": "Update student personal information and settings",
+    "task_details_description": "View and manage task information and attachments",
+    "grade_form_description": "Enter and save student grades for assignments",
+    "delete_confirmation_description": "This action cannot be undone",
+    "command_dialog_description": "Search and run available commands",
+    "edit_name_description": "Update the name and save changes"
   },
   "roles": {
     "admin": "Administrator",

--- a/client/src/i18n/locales/ru.json
+++ b/client/src/i18n/locales/ru.json
@@ -590,8 +590,16 @@
       "completed": "Завершена",
       "in_progress": "В работе",
       "new": "Новая",
-      "on_hold": "Приостановлена"
+    "on_hold": "Приостановлена"
     }
+  },
+  "modals": {
+    "edit_profile_description": "Обновите личные данные студента и настройки",
+    "task_details_description": "Просмотр и управление информацией и вложениями задачи",
+    "grade_form_description": "Введите и сохраните оценки студентов за задания",
+    "delete_confirmation_description": "Это действие нельзя отменить",
+    "command_dialog_description": "Поиск и выполнение доступных команд",
+    "edit_name_description": "Измените название и сохраните изменения"
   },
   "roles": {
     "admin": "Администратор",

--- a/client/src/pages/tasks/TaskDetailsDialog.tsx
+++ b/client/src/pages/tasks/TaskDetailsDialog.tsx
@@ -1,4 +1,4 @@
-import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { StatusBadge, PriorityBadge } from '@/components/tasks/TaskBadges';
 import { format } from 'date-fns';
@@ -23,6 +23,9 @@ export default function TaskDetailsDialog({ open, onOpenChange, task, onEdit, on
       <DialogContent className="sm:max-w-[600px] max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle className="text-xl">{task?.title}</DialogTitle>
+          <DialogDescription>
+            {t('modals.task_details_description')}
+          </DialogDescription>
           <div className="flex flex-wrap gap-2 mt-2">
             {task && (
               <>


### PR DESCRIPTION
## Summary
- add missing `DialogDescription` components in various dialogs
- localize modal descriptions in English and Russian
- wire up translations for command dialog and curriculum plan table

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6858011961208320a186d796a7f08e0a