### PR TITLE
Fix mobile menu accessibility

### DIFF
--- a/client/src/components/layout/main-layout.tsx
+++ b/client/src/components/layout/main-layout.tsx
@@ -10,6 +10,7 @@ import {
   SheetContent,
   SheetHeader,
   SheetTitle,
+  SheetDescription,
   SheetTrigger,
   SheetClose,
 } from "@/components/ui/sheet";
@@ -82,8 +83,11 @@ export function MainLayout({ children, title, subtitle }: MainLayoutProps) {
                 <SheetContent side="left" className="glass-sidebar px-0 sm:max-w-xs">
                   <SheetHeader className="px-6">
                     <SheetTitle className="text-left text-lg bg-gradient-to-r from-indigo-400 to-emerald-300 text-transparent bg-clip-text">
-                      College MS
+                      {t('navigation_menu')}
                     </SheetTitle>
+                    <SheetDescription>
+                      {t('navigation_menu_description')}
+                    </SheetDescription>
                   </SheetHeader>
                   <nav className="flex flex-col gap-4 mt-10 px-6">
                     {navigationItems.map((item) => {

--- a/client/src/i18n/locales/en.json
+++ b/client/src/i18n/locales/en.json
@@ -674,5 +674,7 @@
     "student": "Student"
   },
   "error": "Error",
-  "unexpected_error": "An unexpected error occurred"
+  "unexpected_error": "An unexpected error occurred",
+  "navigation_menu": "Navigation Menu",
+  "navigation_menu_description": "Access different sections of the application"
 }

--- a/client/src/i18n/locales/ru.json
+++ b/client/src/i18n/locales/ru.json
@@ -607,5 +607,7 @@
     "student": "Студент"
   },
   "error": "Ошибка",
-  "unexpected_error": "Произошла непредвиденная ошибка"
+  "unexpected_error": "Произошла непредвиденная ошибка",
+  "navigation_menu": "Меню навигации",
+  "navigation_menu_description": "Доступ к различным разделам приложения"
 }


### PR DESCRIPTION
## Summary
- add `SheetDescription` and localized title for mobile navigation menu
- add translation strings for navigation menu in English and Russian locales

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68581dd74680832089288c07f5717f22