### PR TITLE
Remove duplicate resolvedTheme state

### DIFF
--- a/client/src/components/theme/theme-provider.tsx
+++ b/client/src/components/theme/theme-provider.tsx
@@ -37,8 +37,15 @@ export function ThemeProvider({
 
   const [theme, setTheme] = useState<Theme>(defaultTheme);
   const [isInitialized, setIsInitialized] = useState(false);
+
+  const resolvedTheme: "light" | "dark" =
+    theme === "system"
+      ? typeof window !== "undefined" &&
+        window.matchMedia("(prefers-color-scheme: dark)").matches
+        ? "dark"
+        : "light"
+      : (theme as "light" | "dark");
   
-  const [resolvedTheme, setResolvedTheme] = useState<"light" | "dark">("dark");
 
   useEffect(() => {
     const storedTheme = getStoredTheme();
@@ -84,9 +91,6 @@ export function ThemeProvider({
     // Add new theme class
     root.classList.add(resolvedValue);
     root.style.colorScheme = resolvedValue;
-    
-    // Update state
-    setResolvedTheme(resolvedValue);
     
     // Remove transition class after change is complete
     setTimeout(() => {


### PR DESCRIPTION
## Summary
- cleanup ThemeProvider by removing extra useState for `resolvedTheme`

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_685824e202288320ac7b6aeb970cb584