### PR TITLE
Fix provider order and add I18nextProvider

### DIFF
--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -10,21 +10,24 @@ import { ThemeProvider } from "@/components/theme/theme-provider";
 import { ErrorBoundary } from "@/components/errors/ErrorBoundary";
 
 // Import i18n configuration
-import "./i18n/i18n";
+import { I18nextProvider } from "react-i18next";
+import i18n from "./i18n/i18n";
 
 // Providers wrapped with Error Boundary
 function AppWithProviders() {
   return (
-    <ErrorBoundary>
+    <I18nextProvider i18n={i18n}>
       <ThemeProvider defaultTheme="dark">
         <QueryClientProvider client={queryClient}>
           <AuthProvider>
-            <App />
-            <Toaster />
+            <ErrorBoundary>
+              <App />
+              <Toaster />
+            </ErrorBoundary>
           </AuthProvider>
         </QueryClientProvider>
       </ThemeProvider>
-    </ErrorBoundary>
+    </I18nextProvider>
   );
 }
 


### PR DESCRIPTION
## Summary
- fix provider order in `main.tsx`
- add `I18nextProvider` for localization

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_685828930d2883208586f6a7d1d8f013