### PR TITLE
Add missing Russian translations

### DIFF
--- a/client/src/i18n/locales/en.json
+++ b/client/src/i18n/locales/en.json
@@ -1,6 +1,7 @@
 {
   "common": {
     "locale": "en",
+    "close": "Close",
     "actions": {
       "add": "Add",
       "edit": "Edit",
@@ -514,6 +515,9 @@
     "taskCompleted": "Task completed: {{title}}",
     "taskStatusUpdate": "Task status updated: {{title}}",
     "taskDeleted": "Task deleted: {{title}}",
+    "TaskCompleted": "Task Completed",
+    "TaskDeleted": "Task Deleted",
+    "NewTaskAssigned": "New Task Assigned",
     "titles": {
       "TaskStatusUpdated": "Task Status Updated",
       "TaskCompleted": "Task Completed",

--- a/client/src/i18n/locales/ru.json
+++ b/client/src/i18n/locales/ru.json
@@ -22,6 +22,7 @@
   },
   "common": {
     "locale": "ru",
+    "close": "Закрыть",
     "actions": {
       "add": "Добавить",
       "edit": "Редактировать",
@@ -563,6 +564,9 @@
     "taskCompleted": "Задача завершена: {{title}}",
     "taskStatusUpdate": "Статус задачи обновлен: {{title}}",
     "taskDeleted": "Задача удалена: {{title}}",
+    "TaskCompleted": "Задача завершена",
+    "TaskDeleted": "Задача удалена",
+    "NewTaskAssigned": "Назначена новая задача",
     "titles": {
       "TaskStatusUpdated": "Статус задачи обновлен",
       "TaskCompleted": "Задача завершена",


### PR DESCRIPTION
## Summary
- add root-level `close` translation for en/ru
- include `TaskCompleted`, `TaskDeleted` and `NewTaskAssigned` translations

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_6858fbad00f48320b33fdda8bfb84699