### PR TITLE
Convert UUID to integer IDs during inserts

### DIFF
--- a/server/db/notifications.ts
+++ b/server/db/notifications.ts
@@ -2,6 +2,7 @@ import { db } from './index';
 import * as schema from '@shared/schema';
 import { eq, desc, and } from 'drizzle-orm';
 import { Notification, InsertNotification } from '@shared/schema';
+import { uuidToId } from './utils';
 
 export async function getNotifications(): Promise<Notification[]> {
   return db.select().from(schema.notifications);
@@ -38,6 +39,7 @@ export async function createNotification(notificationData: InsertNotification): 
   const [notification] = await db.insert(schema.notifications)
     .values({
       ...notificationData,
+      userId: uuidToId(notificationData.userId),
       isRead: false,
       createdAt: new Date(),
     })

--- a/server/db/storage.ts
+++ b/server/db/storage.ts
@@ -10,6 +10,7 @@ import pg from 'pg';
 import { getOrSet } from '../utils/cache';
 
 import * as notificationQueries from './notifications';
+import { uuidToId } from './utils';
 
 const { Pool } = pg;
 import {
@@ -164,7 +165,10 @@ export class SupabaseStorage {
 
   async createEnrollment(enrollmentData: InsertEnrollment): Promise<Enrollment> {
     const [enrollment] = await db.insert(schema.enrollments)
-      .values(enrollmentData)
+      .values({
+        ...enrollmentData,
+        studentId: uuidToId(enrollmentData.studentId),
+      })
       .returning();
     
     return enrollment;
@@ -309,7 +313,10 @@ export class SupabaseStorage {
 
   async createAssignment(assignmentData: InsertAssignment): Promise<Assignment> {
     const [assignment] = await db.insert(schema.assignments)
-      .values(assignmentData)
+      .values({
+        ...assignmentData,
+        createdBy: uuidToId(assignmentData.createdBy),
+      })
       .returning();
     
     return assignment;
@@ -371,7 +378,10 @@ export class SupabaseStorage {
 
   async createSubmission(submissionData: InsertSubmission): Promise<Submission> {
     const [submission] = await db.insert(schema.submissions)
-      .values(submissionData)
+      .values({
+        ...submissionData,
+        studentId: uuidToId(submissionData.studentId),
+      })
       .returning();
     
     return submission;
@@ -431,7 +441,10 @@ export class SupabaseStorage {
 
   async createGrade(gradeData: InsertGrade): Promise<Grade> {
     const [grade] = await db.insert(schema.grades)
-      .values(gradeData)
+      .values({
+        ...gradeData,
+        studentId: uuidToId(gradeData.studentId),
+      })
       .returning();
     
     return grade;
@@ -482,6 +495,7 @@ export class SupabaseStorage {
     const [request] = await db.insert(schema.requests)
       .values({
         ...requestData,
+        studentId: uuidToId(requestData.studentId),
         status: 'pending'
       })
       .returning();
@@ -542,7 +556,13 @@ export class SupabaseStorage {
 
   async createDocument(documentData: InsertDocument): Promise<Document> {
     const [document] = await db.insert(schema.documents)
-      .values(documentData)
+      .values({
+        ...documentData,
+        userId: uuidToId(documentData.userId),
+        createdBy: documentData.createdBy
+          ? uuidToId(documentData.createdBy)
+          : null,
+      })
       .returning();
     
     return document;
@@ -611,6 +631,8 @@ export class SupabaseStorage {
     const [message] = await db.insert(schema.messages)
       .values({
         ...messageData,
+        fromUserId: uuidToId(messageData.fromUserId),
+        toUserId: uuidToId(messageData.toUserId),
         status: 'sent'
       })
       .returning();
@@ -691,7 +713,10 @@ export class SupabaseStorage {
 
   async createImportedFile(fileData: InsertImportedFile): Promise<ImportedFile> {
     const [file] = await db.insert(schema.importedFiles)
-      .values(fileData)
+      .values({
+        ...fileData,
+        uploadedBy: uuidToId(fileData.uploadedBy),
+      })
       .returning();
     
     return file;
@@ -783,7 +808,10 @@ export class SupabaseStorage {
   
   async createActivityLog(logData: InsertActivityLog): Promise<ActivityLog> {
     const [log] = await db.insert(schema.activityLogs)
-      .values(logData)
+      .values({
+        ...logData,
+        userId: uuidToId(logData.userId),
+      })
       .returning();
     
     return log;
@@ -882,9 +910,10 @@ export class SupabaseStorage {
     const plan = {
       ...planData,
       createdAt: now,
-      updatedAt: now
+      updatedAt: now,
+      createdBy: planData.createdBy ? uuidToId(planData.createdBy) : null,
     };
-    
+
     const result = await db.insert(schema.curriculumPlans)
       .values(plan)
       .returning();

--- a/server/db/subjects/repository.ts
+++ b/server/db/subjects/repository.ts
@@ -2,6 +2,7 @@ import { db } from '../index';
 import * as schema from '@shared/schema';
 import { eq } from 'drizzle-orm';
 import { Subject, InsertSubject } from '@shared/schema';
+import { uuidToId } from '../utils';
 
 export class SubjectsRepository {
   async getSubjects(): Promise<Subject[]> {
@@ -24,7 +25,12 @@ export class SubjectsRepository {
 
   async createSubject(subjectData: InsertSubject): Promise<Subject> {
     const [subject] = await db.insert(schema.subjects)
-      .values(subjectData)
+      .values({
+        ...subjectData,
+        teacherId: subjectData.teacherId
+          ? uuidToId(subjectData.teacherId)
+          : undefined,
+      })
       .returning();
     return subject;
   }

--- a/server/db/tasks/repository.ts
+++ b/server/db/tasks/repository.ts
@@ -1,6 +1,7 @@
 import { db } from '../index';
 import * as schema from '@shared/schema';
 import { eq, and, or, desc, asc, sql, isNotNull } from 'drizzle-orm';
+import { uuidToId } from '../utils';
 import { aliasedTable } from 'drizzle-orm/alias';
 import { Task, InsertTask, UserSummary } from '@shared/schema';
 
@@ -415,7 +416,11 @@ export class TasksRepository {
 
   async createTask(taskData: InsertTask): Promise<Task> {
     const [task] = await db.insert(schema.tasks)
-      .values(taskData)
+      .values({
+        ...taskData,
+        clientId: uuidToId(taskData.clientId),
+        executorId: uuidToId(taskData.executorId),
+      })
       .returning();
     return task;
   }

--- a/server/db/utils.ts
+++ b/server/db/utils.ts
@@ -1,0 +1,8 @@
+import { sql } from 'drizzle-orm';
+
+/**
+ * Convert Supabase UUID to numeric user id using a subquery.
+ */
+export function uuidToId(uuid: string) {
+  return sql<number>`(SELECT id FROM users WHERE auth_user_id = ${uuid})`;
+}


### PR DESCRIPTION
## Summary
- add `uuidToId` helper for mapping Supabase UUIDs to integer IDs
- update create queries in DB layer to use the helper

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_685929c3d6c4832090447c7a66178f9e