### PR TITLE
Fix grade routes to use user UUID

### DIFF
--- a/server/routes/assignments.ts
+++ b/server/routes/assignments.ts
@@ -331,7 +331,7 @@ export function registerAssignmentRoutes(app: Express, { authenticateUser, requi
   // Grade Routes
   app.get('/api/grades/student/:studentId', authenticateUser, async (req, res) => {
     try {
-      const studentId = parseInt(req.params.studentId);
+      const studentId = req.params.studentId;
 
       if (req.user!.id !== studentId && req.user!.role === 'student') {
         return res.status(403).json({ message: "Forbidden" });


### PR DESCRIPTION
## Summary
- use the UUID from `req.user.id` when fetching grades for a student

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6859308f5ffc8320b48223d3a4a08049