### PR TITLE
Fix routes to use req.user.id

### DIFF
--- a/server/auth.ts
+++ b/server/auth.ts
@@ -224,7 +224,7 @@ export function setupAuth(app: Express) {
 
     const responseUser = {
       id: req.user.id,
-      publicId: req.user.publicId,
+      publicId: req.user.id,
       email: req.user.email,
       firstName: req.user.firstName,
       lastName: req.user.lastName,

--- a/server/routes/requests.ts
+++ b/server/routes/requests.ts
@@ -76,7 +76,7 @@ export function registerRequestRoutes(app: Express, { authenticateUser, requireR
       const updatedRequest = await getStorage().updateRequestStatus(
         requestId,
         status as 'approved' | 'rejected',
-        req.user!.publicId,
+        req.user!.id,
         resolution
       );
 


### PR DESCRIPTION
## Summary
- adjust `/api/user` route to use UUID for publicId
- update requests routes to use `req.user.id`

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6859338bade88320a885fb5eb368b824