### PR TITLE
Switch user references to UUID strings

### DIFF
--- a/client/src/components/grades/GradeForm.tsx
+++ b/client/src/components/grades/GradeForm.tsx
@@ -32,7 +32,7 @@ const GradeForm: React.FC<GradeFormProps> = ({ students, subjects, onSubmit }) =
   const form = useForm<z.infer<typeof gradeFormSchema>>({
     resolver: zodResolver(gradeFormSchema),
     defaultValues: {
-      studentId: 0,
+      studentId: '',
       subjectId: 0,
       assignmentId: null,
       score: 0,
@@ -73,8 +73,8 @@ const GradeForm: React.FC<GradeFormProps> = ({ students, subjects, onSubmit }) =
                   <FormItem>
                     <FormLabel>Student</FormLabel>
                     <Select
-                      onValueChange={(value) => field.onChange(parseInt(value))}
-                      defaultValue={field.value.toString()}
+                      onValueChange={field.onChange}
+                      defaultValue={field.value}
                     >
                       <FormControl>
                         <SelectTrigger>

--- a/client/src/components/notifications/NotificationBell.tsx
+++ b/client/src/components/notifications/NotificationBell.tsx
@@ -20,7 +20,7 @@ import { useToast } from '@/hooks/use-toast';
 // Определение типа для уведомлений
 export interface Notification {
   id: number;
-  userId: number;
+  userId: string;
   title: string;
   content: string;
   isRead: boolean;

--- a/client/src/components/requests/RequestList.tsx
+++ b/client/src/components/requests/RequestList.tsx
@@ -47,14 +47,14 @@ const RequestList: React.FC<RequestListProps> = ({
     }
   }, [error, toast, t]);
   
-  const getStudentName = (studentId: number) => {
-    const student = users.find(user => user.id === studentId);
+  const getStudentName = (studentId: string) => {
+    const student = users.find(user => user.authUserId === studentId);
     return student ? `${student.firstName} ${student.lastName}` : `Student ID: ${studentId}`;
   };
-  
-  const getResolverName = (userId: number | null) => {
+
+  const getResolverName = (userId: string | null) => {
     if (!userId) return 'N/A';
-    const user = users.find(user => user.id === userId);
+    const user = users.find(user => user.authUserId === userId);
     return user ? `${user.firstName} ${user.lastName}` : `User ID: ${userId}`;
   };
   

--- a/client/src/components/students/StudentDocuments.tsx
+++ b/client/src/components/students/StudentDocuments.tsx
@@ -13,16 +13,16 @@ import {
 // Интерфейс для данных документа
 export interface Document {
   id: number;
-  userId: number;
+  userId: string;
   title: string;
   type: string;
   fileUrl?: string;
   createdAt: string;
-  createdBy?: number;
+  createdBy?: string;
 }
 
 interface StudentDocumentsProps {
-  userId: number;
+  userId: string;
   documents: Document[];
   isLoading: boolean;
 }

--- a/client/src/components/students/StudentTaskItem.tsx
+++ b/client/src/components/students/StudentTaskItem.tsx
@@ -16,7 +16,7 @@ export interface Task {
   status: 'new' | 'in_progress' | 'completed' | 'on_hold';
   createdAt: string;
   updatedAt?: string;
-  createdBy?: number;
+  createdBy?: string;
   creatorName?: string;
   dueDate?: string;
   priority?: 'high' | 'medium' | 'low';
@@ -24,7 +24,7 @@ export interface Task {
 
 interface StudentTaskItemProps {
   task: Task;
-  userId: number;
+  userId: string;
 }
 
 const StudentTaskItem: React.FC<StudentTaskItemProps> = ({ 

--- a/client/src/components/students/StudentTasks.tsx
+++ b/client/src/components/students/StudentTasks.tsx
@@ -4,7 +4,7 @@ import StudentTaskItem, { Task } from './StudentTaskItem';
 import { AlertCircle } from 'lucide-react';
 
 interface StudentTasksProps {
-  userId: number;
+  userId: string;
   tasks: Task[];
   isLoading: boolean;
 }

--- a/client/src/components/tasks/TaskDetailsModal.tsx
+++ b/client/src/components/tasks/TaskDetailsModal.tsx
@@ -32,7 +32,7 @@ interface TaskDetailsModalProps {
   onOpenChange: (open: boolean) => void;
   onStatusChange?: (taskId: number, status: string) => void;
   onAfterStatusChange?: () => void;
-  userId: number;
+  userId: string;
 }
 
 const TaskDetailsModal: React.FC<TaskDetailsModalProps> = ({ 

--- a/client/src/hooks/useStudentDetail.ts
+++ b/client/src/hooks/useStudentDetail.ts
@@ -31,8 +31,8 @@ interface ScheduleItem {
   };
 }
 
-export function useStudentDetail(id: number | string | undefined) {
-  const userId = Number(id);
+export function useStudentDetail(id: string | undefined) {
+  const userId = id;
 
   const {
     data: userData,
@@ -43,7 +43,7 @@ export function useStudentDetail(id: number | string | undefined) {
     queryFn: async () => {
       return await apiRequest(`/api/users/${userId}`) as UserData;
     },
-    enabled: !!userId && !isNaN(userId),
+    enabled: !!userId,
   });
 
   const {
@@ -54,7 +54,7 @@ export function useStudentDetail(id: number | string | undefined) {
     queryFn: async () => {
       return await apiRequest(`/api/users/${userId}/notifications`) as Notification[];
     },
-    enabled: !!userId && !isNaN(userId),
+    enabled: !!userId,
   });
 
   const {
@@ -65,7 +65,7 @@ export function useStudentDetail(id: number | string | undefined) {
     queryFn: async () => {
       return await apiRequest(`/api/users/${userId}/tasks`) as Task[];
     },
-    enabled: !!userId && !isNaN(userId) && userData?.role === 'student',
+    enabled: !!userId && userData?.role === 'student',
   });
 
   const { data: scheduleItems = [] } = useQuery({

--- a/client/src/pages/documents/DocumentPage.tsx
+++ b/client/src/pages/documents/DocumentPage.tsx
@@ -29,7 +29,7 @@ interface DocumentPageProps {
 const documentFormSchema = insertDocumentSchema.extend({
   title: z.string().min(3, 'Title must be at least 3 characters'),
   type: z.string().min(1, 'Document type is required'),
-  userId: z.number().positive('Please select a user'),
+  userId: z.string().min(1, 'Please select a user'),
 });
 
 export default function DocumentPage({ documentType, title, icon: Icon }: DocumentPageProps) {
@@ -51,7 +51,7 @@ export default function DocumentPage({ documentType, title, icon: Icon }: Docume
 
   const form = useForm<z.infer<typeof documentFormSchema>>({
     resolver: zodResolver(documentFormSchema),
-    defaultValues: { title: '', type: documentType, userId: 0 },
+    defaultValues: { title: '', type: documentType, userId: '' },
   });
 
   const createDocumentMutation = useMutation({
@@ -64,7 +64,7 @@ export default function DocumentPage({ documentType, title, icon: Icon }: Docume
         description: `The ${documentType} has been created successfully.`,
       });
       setIsDialogOpen(false);
-      form.reset({ title: '', type: documentType, userId: 0 });
+      form.reset({ title: '', type: documentType, userId: '' });
     },
     onError: () => {
       setError(`Failed to create ${documentType}. Please try again.`);
@@ -76,7 +76,7 @@ export default function DocumentPage({ documentType, title, icon: Icon }: Docume
     const formData = new FormData();
     formData.append('title', data.title);
     formData.append('type', data.type);
-    formData.append('userId', data.userId.toString());
+    formData.append('userId', data.userId);
     createDocumentMutation.mutate(formData);
   };
 
@@ -130,7 +130,7 @@ export default function DocumentPage({ documentType, title, icon: Icon }: Docume
                       render={({ field }) => (
                         <FormItem>
                           <FormLabel>Student</FormLabel>
-                          <Select onValueChange={(value) => field.onChange(parseInt(value))} defaultValue={field.value ? field.value.toString() : undefined}>
+                          <Select onValueChange={field.onChange} defaultValue={field.value || undefined}>
                             <FormControl>
                               <SelectTrigger>
                                 <SelectValue placeholder="Select a student" />
@@ -229,7 +229,7 @@ export default function DocumentPage({ documentType, title, icon: Icon }: Docume
                   <CardContent>
                     <p className="text-sm text-neutral-500">{documentType === 'invoice' ? 'Created' : 'Issued'}: {formatDate(document.createdAt)}</p>
                     {isAdmin && (
-                      <p className="text-sm text-neutral-500">For: {users.find(u => u.id === document.userId)?.firstName} {users.find(u => u.id === document.userId)?.lastName}</p>
+                      <p className="text-sm text-neutral-500">For: {users.find(u => u.authUserId === document.userId)?.firstName} {users.find(u => u.authUserId === document.userId)?.lastName}</p>
                     )}
                   </CardContent>
                   <CardFooter className="flex justify-end">

--- a/client/src/pages/students/StudentDetail.tsx
+++ b/client/src/pages/students/StudentDetail.tsx
@@ -12,7 +12,7 @@ import useStudentDetail from '@/hooks/useStudentDetail';
 export default function StudentDetail() {
   const { id } = useParams<{ id: string }>();
   const { t } = useTranslation();
-  const userId = parseInt(id);
+  const userId = id;
   const {
     userData,
     studentData,

--- a/client/src/types/notifications.ts
+++ b/client/src/types/notifications.ts
@@ -1,6 +1,6 @@
 export interface Notification {
   id: number;
-  userId: number;
+  userId: string;
   title: string;
   content: string;
   isRead: boolean;


### PR DESCRIPTION
## Summary
- update Notification type to use `string` userId
- adjust student document/task components for UUID user IDs
- expect string IDs in notifications and tasks modal
- handle UUIDs in requests list and grade form
- adapt student detail hooks and document page

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_68593c6e05e483209bed18267b3720c1