### PR TITLE
Fix ID handling to use UUID strings

### DIFF
--- a/client/src/components/users/AdminCard.tsx
+++ b/client/src/components/users/AdminCard.tsx
@@ -20,7 +20,7 @@ export interface Admin extends UserData {
 
 interface AdminCardProps {
   admin: Admin;
-  onClick?: (id: number) => void;
+  onClick?: (id: string) => void;
   onEdit?: (admin: Admin) => void;
 }
 

--- a/client/src/components/users/DirectorCard.tsx
+++ b/client/src/components/users/DirectorCard.tsx
@@ -22,7 +22,7 @@ export interface Director extends UserData {
 
 interface DirectorCardProps {
   director: Director;
-  onClick?: (id: number) => void;
+  onClick?: (id: string) => void;
   onEdit?: (director: Director) => void;
 }
 

--- a/client/src/components/users/EditUserProfileModal.tsx
+++ b/client/src/components/users/EditUserProfileModal.tsx
@@ -37,7 +37,7 @@ import { useAuth } from '@/hooks/use-auth';
 
 // Интерфейс для данных пользователя
 export interface UserProfile {
-  id: number;
+  id: string;
   firstName: string;
   lastName: string;
   email: string;

--- a/client/src/components/users/StudentCard.tsx
+++ b/client/src/components/users/StudentCard.tsx
@@ -64,7 +64,7 @@ export interface Student extends UserData {
 
 interface StudentCardProps {
   student: Student;
-  onClick?: (id: number) => void;
+  onClick?: (id: string) => void;
   onEdit?: (student: Student) => void;
 }
 

--- a/client/src/components/users/TeacherCard.tsx
+++ b/client/src/components/users/TeacherCard.tsx
@@ -34,7 +34,7 @@ export interface Teacher extends UserData {
 
 interface TeacherCardProps {
   teacher: Teacher;
-  onClick?: (id: number) => void;
+  onClick?: (id: string) => void;
   onEdit?: (teacher: Teacher) => void;
 }
 

--- a/client/src/components/users/UserCard.tsx
+++ b/client/src/components/users/UserCard.tsx
@@ -7,7 +7,7 @@ import { useTranslation } from 'react-i18next';
 
 // Базовый интерфейс с данными пользователя
 export interface UserData {
-  id: number;
+  id: string;
   firstName: string;
   lastName: string;
   email: string;
@@ -18,7 +18,7 @@ export interface UserData {
 
 interface UserCardProps {
   user: UserData;
-  onClick?: (id: number) => void;
+  onClick?: (id: string) => void;
 }
 
 const UserCard: React.FC<UserCardProps> = ({ user, onClick }) => {

--- a/client/src/hooks/useStudentDetail.ts
+++ b/client/src/hooks/useStudentDetail.ts
@@ -6,7 +6,7 @@ import StudentCard, { Student, UpcomingLesson } from '@/components/students/Stud
 import { Task } from '@/components/students/StudentTaskItem';
 
 interface UserData {
-  id: number;
+  id: string;
   firstName: string;
   lastName: string;
   email: string;

--- a/client/src/pages/users/UserDetail.tsx
+++ b/client/src/pages/users/UserDetail.tsx
@@ -19,7 +19,7 @@ import DirectorCard, { Director } from '@/components/users/DirectorCard';
 
 // Интерфейс базового пользователя
 interface User {
-  id: number;
+  id: string;
   firstName: string;
   lastName: string;
   email: string;

--- a/client/src/pages/users/Users.tsx
+++ b/client/src/pages/users/Users.tsx
@@ -27,7 +27,7 @@ import { z } from 'zod';
 
 // Define the User type
 interface User {
-  id: number;
+  id: string;
   firstName: string;
   lastName: string;
   email: string;
@@ -157,7 +157,7 @@ export default function Users() {
 
   // Update user mutation
   const updateUserMutation = useMutation({
-    mutationFn: async ({ id, userData }: { id: number, userData: Partial<InsertUser> }) => {
+    mutationFn: async ({ id, userData }: { id: string, userData: Partial<InsertUser> }) => {
       return await apiRequest(`/api/users/${id}`, 'PUT', userData) as User;
     },
     onSuccess: () => {
@@ -183,7 +183,7 @@ export default function Users() {
 
   // Delete user mutation
   const deleteUserMutation = useMutation({
-    mutationFn: async (id: number) => {
+    mutationFn: async (id: string) => {
       await apiRequest(`/api/users/${id}`, 'DELETE');
       return Promise.resolve();
     },

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -107,10 +107,10 @@ export async function registerRoutes(app: Express): Promise<Server> {
   setupAuth(app);
   
   // Store active connections with user IDs
-  const connections = new Map<number, WebSocket>();
+  const connections = new Map<string, WebSocket>();
   
   wss.on('connection', (ws) => {
-    let userId: number | null = null;
+    let userId: string | null = null;
     
     ws.on('message', async (message) => {
       try {
@@ -118,7 +118,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         
         // Handle authentication
         if (data.type === 'auth') {
-          userId = Number(data.userId);
+          userId = data.userId as string;
           connections.set(userId, ws);
           logger.info(`User ${userId} connected to WebSocket`);
           


### PR DESCRIPTION
## Summary
- switch user-related ID types from number to string
- adjust profile modals and user cards
- update user pages and hooks
- update websocket auth to store string user IDs

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_68593f3507508320849ed9d2e232a13c