### PR TITLE
Remove leftover publicId references

### DIFF
--- a/client/src/components/dashboards/NewAdminDashboard.tsx
+++ b/client/src/components/dashboards/NewAdminDashboard.tsx
@@ -16,8 +16,8 @@ interface Task {
   status: 'new' | 'in_progress' | 'completed' | 'on_hold';
   priority: 'high' | 'medium' | 'low';
   dueDate: string | null;
-  clientId: number;
-  executorId: number;
+  clientId: string;
+  executorId: string;
   createdAt: string;
   updatedAt: string;
 }

--- a/client/src/components/tasks/TaskDetailsModal.tsx
+++ b/client/src/components/tasks/TaskDetailsModal.tsx
@@ -19,8 +19,8 @@ export interface TaskDetail {
   createdAt: string;
   updatedAt?: string;
   dueDate?: string;
-  clientId?: number;
-  executorId?: number;
+  clientId?: string;
+  executorId?: string;
   creatorName?: string;
   executorName?: string;
   priority?: 'high' | 'medium' | 'low';

--- a/client/src/hooks/use-auth.tsx
+++ b/client/src/hooks/use-auth.tsx
@@ -12,7 +12,6 @@ export type UserRole = 'admin' | 'teacher' | 'student';
 // Тип пользователя, возвращаемого эндпоинтом /api/user
 export interface AuthUser {
   id: string; // UUID из auth.users
-  publicId: number; // числовой ID из public.users
   firstName: string;
   lastName: string;
   email: string;

--- a/client/src/pages/tasks/useTasks.ts
+++ b/client/src/pages/tasks/useTasks.ts
@@ -19,8 +19,8 @@ export interface Task {
   createdAt: string;
   updatedAt: string;
   dueDate: string | null;
-  clientId: number;
-  executorId: number;
+  clientId: string;
+  executorId: string;
   client?: { firstName: string; lastName: string };
   executor?: { firstName: string; lastName: string };
 }
@@ -30,7 +30,7 @@ const taskFormSchema = z.object({
   description: z.string().optional(),
   priority: z.enum(['high', 'medium', 'low']),
   status: z.enum(['new', 'in_progress', 'on_hold']),
-  executorId: z.number(),
+  executorId: z.string(),
   dueDate: z.date().nullable().optional(),
 });
 
@@ -60,7 +60,7 @@ export function useTasks() {
       description: '',
       status: 'new',
       priority: 'medium',
-      executorId: 0,
+      executorId: '',
       dueDate: null,
     },
   });
@@ -72,7 +72,7 @@ export function useTasks() {
       description: '',
       status: 'new',
       priority: 'medium',
-      executorId: 0,
+      executorId: '',
       dueDate: null,
     },
   });
@@ -156,7 +156,7 @@ export function useTasks() {
       status?: string;
       priority?: string;
       dueDate?: string | null;
-      executorId?: number;
+      executorId?: string;
     }) => {
       const { id, ...taskData } = data;
       const result = await apiRequest(`/api/tasks/${id}`, 'PUT', taskData);
@@ -199,7 +199,7 @@ export function useTasks() {
       ...data,
       description: data.description || '',
       dueDate: data.dueDate ? data.dueDate.toISOString() : null,
-      clientId: user?.publicId as number,
+      clientId: user?.id,
     } as InsertTask;
 
     createTaskMutation.mutate(taskData);

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -224,7 +224,6 @@ export function setupAuth(app: Express) {
 
     const responseUser = {
       id: req.user.id,
-      publicId: req.user.id,
       email: req.user.email,
       firstName: req.user.firstName,
       lastName: req.user.lastName,

--- a/server/middleware/verifySupabaseJwt.ts
+++ b/server/middleware/verifySupabaseJwt.ts
@@ -43,7 +43,6 @@ export async function verifySupabaseJwt(req: Request, res: Response, next: NextF
     const mergedUser: AuthenticatedUser = {
       id: data.user.id,
       email: data.user.email || '',
-      publicId: dbUser.id,
       firstName: dbUser.firstName,
       lastName: dbUser.lastName,
       role: dbUser.role,

--- a/server/types/auth.ts
+++ b/server/types/auth.ts
@@ -2,7 +2,6 @@ export type UserRole = 'admin' | 'teacher' | 'student';
 
 export interface AuthenticatedUser {
   id: string; // Supabase UUID
-  publicId: number; // Database ID
   email: string;
   firstName: string;
   lastName: string;


### PR DESCRIPTION
## Summary
- drop `publicId` from `AuthenticatedUser`
- clean up auth middleware and routes
- refactor task types to use string IDs

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_68594ba9f8988320b332ca843560425a