### PR TITLE
Add missing Russian notification translations

### DIFF
--- a/client/src/i18n/locales/ru.json
+++ b/client/src/i18n/locales/ru.json
@@ -567,6 +567,8 @@
     "TaskCompleted": "Задача завершена",
     "TaskDeleted": "Задача удалена",
     "NewTaskAssigned": "Назначена новая задача",
+    "UserUpdated": "Пользователь обновлен",
+    "TaskStatusUpdated": "Статус задачи обновлен",
     "titles": {
       "TaskStatusUpdated": "Статус задачи обновлен",
       "TaskCompleted": "Задача завершена",


### PR DESCRIPTION
## Summary
- add `UserUpdated` and `TaskStatusUpdated` Russian strings

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_68595f0c60ec8320a0ace65b685ac8c3