### PR TITLE
Fix student schedule endpoint and enable request routes

### DIFF
--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -200,7 +200,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   registerNotificationRoutes(app, ctx);
 
   // Временное отключение второстепенных модулей
-  // registerRequestRoutes(app, ctx);
+  registerRequestRoutes(app, ctx);
   // registerDocumentRoutes(app, ctx);
   // registerActivityLogRoutes(app, ctx);
   // registerCurriculumRoutes(app, ctx);

--- a/server/routes/schedule.ts
+++ b/server/routes/schedule.ts
@@ -269,13 +269,13 @@ app.get('/schedule-template.csv', (req, res) => {
 
 app.get('/api/schedule/student/:studentId', authenticateUser, async (req, res) => {
   try {
-    const studentId = parseInt(req.params.studentId);
-    
+    const studentId = req.params.studentId;
+
     // Students can only view their own schedule unless they're admins/teachers
     if (req.user!.id !== studentId && req.user!.role === 'student') {
       return res.status(403).json({ message: "Forbidden" });
     }
-    
+
     const schedule = await getStorage().getScheduleItemsByStudent(studentId);
     res.json(schedule);
   } catch (error) {


### PR DESCRIPTION
## Summary
- correct student schedule route to treat IDs as strings
- enable request routes in the server router

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68596676b8c08320832ae617d6d54ff0