### PR TITLE
Fix user mapping to return authUserId

### DIFF
--- a/server/utils/userMapping.ts
+++ b/server/utils/userMapping.ts
@@ -15,7 +15,7 @@ export async function getDbUserBySupabaseUser(supabaseUser: Pick<User, 'email' |
     }
 
     return {
-      id: user.id,
+      id: user.authUserId || user.id,
       firstName: user.firstName,
       lastName: user.lastName,
       email: user.email,


### PR DESCRIPTION
## Summary
- use `authUserId` instead of numeric `id` when mapping supabase user records

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6859a1bdbbd08320b0079f6f3d3a42c1