### PR TITLE
Add global request logging

### DIFF
--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -99,6 +99,22 @@ async function getDefaultTeacherId(): Promise<number> {
 
 export async function registerRoutes(app: Express): Promise<Server> {
   const httpServer = createServer(app);
+
+  // Global middleware to trace chat and user requests
+  app.use('/api/users/chat', (req, res, next) => {
+    console.log('🚨 [GLOBAL] /api/users/chat intercepted!');
+    console.log('🚨 [GLOBAL] Method:', req.method);
+    console.log('🚨 [GLOBAL] Headers:', req.headers);
+    console.log('🚨 [GLOBAL] User:', (req as any).user);
+    next();
+  });
+
+  // Log all /api/users requests
+  app.use('/api/users', (req, _res, next) => {
+    console.log('🔍 [GLOBAL] /api/users/* hit:', req.path);
+    console.log('🔍 [GLOBAL] Full URL:', req.url);
+    next();
+  });
   
   // Set up WebSockets for real-time chat
   const wss = new WebSocketServer({ server: httpServer, path: '/ws' });

--- a/server/routes/messages.ts
+++ b/server/routes/messages.ts
@@ -75,4 +75,12 @@ export function registerMessageRoutes(app: Express, { authenticateUser }: RouteC
       res.status(500).json({ message: "Server error" });
     }
   });
+
+  // 🔍 [DEBUG] Log all registered routes for verification
+  console.log('🔍 [DEBUG] All registered routes:');
+  (app as any)._router.stack.forEach((middleware, index) => {
+    if (middleware.route) {
+      console.log(`Route ${index}: ${middleware.route.path}`);
+    }
+  });
 }


### PR DESCRIPTION
## Summary
- log all `/api/users` requests to debug lost `/chat` calls
- print registered routes for `registerMessageRoutes`

## Testing
- `npm run check`
- `npm run dev:server` *(fails: esbuild for another platform)*

------
https://chatgpt.com/codex/tasks/task_e_685a2ff10d0c8320b4e940117de93462