### PR TITLE
Fix chat route ordering

### DIFF
--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -206,13 +206,14 @@ export async function registerRoutes(app: Express): Promise<Server> {
   // Auth Routes are handled in server/auth.ts
 
   const ctx: RouteContext = { authenticateUser, requireRole, upload };
+  // Register chat-related routes before user routes to avoid conflicts
+  registerMessageRoutes(app, ctx);
   registerUserRoutes(app, ctx);
   registerScheduleRoutes(app, ctx);
   registerTaskRoutes(app, ctx);
 
   // Основные разделы
   registerAssignmentRoutes(app, ctx);
-  registerMessageRoutes(app, ctx);
   registerNotificationRoutes(app, ctx);
 
   // Временное отключение второстепенных модулей


### PR DESCRIPTION
## Summary
- register message routes before user routes

## Testing
- `npm run check`
- `node --test server/routes/__tests__/messages.read.test.js`


------
https://chatgpt.com/codex/tasks/task_e_685a35d633508320b2ba1970eeb605bd