### PR TITLE
Fix notification userId mapping

### DIFF
--- a/server/routes/assignments.ts
+++ b/server/routes/assignments.ts
@@ -83,7 +83,7 @@ export function registerAssignmentRoutes(app: Express, { authenticateUser, requi
       const students = await getStorage().getStudentsBySubject(assignmentData.subjectId);
       for (const student of students) {
         await getStorage().createNotification({
-          userId: student.id,
+          userId: student.authUserId,
           title: "New Assignment",
           content: `A new assignment "${assignment.title}" has been posted for ${assignment.subjectId}.`,
           relatedId: assignment.id,

--- a/server/routes/curriculum.ts
+++ b/server/routes/curriculum.ts
@@ -95,7 +95,7 @@ export function registerCurriculumRoutes(app: Express, { authenticateUser, requi
       const admins = await storage.getUsersByRole('admin');
       for (const admin of admins) {
         if (admin.id !== req.user?.id) {
-          await storage.createNotification({ userId: admin.id, title: "Создан учебный план", content: `Учебный план \"${plan.specialtyName}\" (${plan.specialtyCode}) был создан`, relatedId: plan.id, relatedType: "curriculum_plan" });
+          await storage.createNotification({ userId: admin.authUserId, title: "Создан учебный план", content: `Учебный план \"${plan.specialtyName}\" (${plan.specialtyCode}) был создан`, relatedId: plan.id, relatedType: "curriculum_plan" });
         }
       }
       res.status(201).json(plan);
@@ -130,7 +130,7 @@ export function registerCurriculumRoutes(app: Express, { authenticateUser, requi
       const admins = await storage.getUsersByRole('admin');
       for (const admin of admins) {
         if (admin.id !== req.user?.id) {
-          await storage.createNotification({ userId: admin.id, title: "Обновлен учебный план", content: `Учебный план \"${plan.specialtyName}\" (${plan.specialtyCode}) был обновлен`, relatedId: plan.id, relatedType: "curriculum_plan" });
+          await storage.createNotification({ userId: admin.authUserId, title: "Обновлен учебный план", content: `Учебный план \"${plan.specialtyName}\" (${plan.specialtyCode}) был обновлен`, relatedId: plan.id, relatedType: "curriculum_plan" });
         }
       }
       res.json(updatedPlan);
@@ -170,7 +170,7 @@ export function registerCurriculumRoutes(app: Express, { authenticateUser, requi
       const admins = await storage.getUsersByRole('admin');
       for (const admin of admins) {
         if (admin.id !== req.user?.id) {
-          await storage.createNotification({ userId: admin.id, title: "Удален учебный план", content: `Учебный план \"${plan.specialtyName}\" (${plan.specialtyCode}) был удален`, relatedType: "curriculum_plan" });
+          await storage.createNotification({ userId: admin.authUserId, title: "Удален учебный план", content: `Учебный план \"${plan.specialtyName}\" (${plan.specialtyCode}) был удален`, relatedType: "curriculum_plan" });
         }
       }
       res.status(200).json({ message: "Curriculum plan deleted successfully", planId });

--- a/server/routes/requests.ts
+++ b/server/routes/requests.ts
@@ -41,7 +41,7 @@ export function registerRequestRoutes(app: Express, { authenticateUser, requireR
       if (req.user) {
         for (const admin of admins) {
           await getStorage().createNotification({
-            userId: admin.id,
+            userId: admin.authUserId,
             title: "New Student Request",
             content: `${req.user.firstName} ${req.user.lastName} has submitted a ${requestData.type} request.`,
             relatedId: request.id,

--- a/server/routes/users.ts
+++ b/server/routes/users.ts
@@ -84,7 +84,7 @@ app.post('/api/users', authenticateUser, requireRole(['admin']), async (req, res
     for (const admin of admins) {
       if (admin.id !== req.user?.id) {
         await getStorage().createNotification({
-          userId: admin.id,
+          userId: admin.authUserId,
           title: "New User Registered",
           content: `A new user ${fullName} has been registered with role: ${user.role}`,
           relatedId: user.id,
@@ -130,7 +130,7 @@ app.put('/api/users/:id', authenticateUser, requireRole(['admin']), async (req, 
       if (req.user && req.user.id !== updatedUser.id) {
         logger.info(`📨 Creating notification for updated user (ID: ${updatedUser.id})`);
         const userNotification = await storage.createNotification({
-          userId: updatedUser.id,
+          userId: updatedUser.authUserId,
           title: "User Updated",
           content: `Ваш профиль был обновлён администратором.`,
           relatedType: "user",
@@ -163,7 +163,7 @@ app.put('/api/users/:id', authenticateUser, requireRole(['admin']), async (req, 
           if (admin.id !== req.user.id) {
             logger.info(`📨 Creating notification for other admin (ID: ${admin.id})`);
             const otherAdminNotification = await storage.createNotification({
-              userId: admin.id,
+              userId: admin.authUserId,
               title: "User Updated",
               content: `Профиль пользователя ${fullName} был обновлён.`,
               relatedType: "user",


### PR DESCRIPTION
## Summary
- use authUserId when creating notifications
- update routes to reference authUserId instead of numeric id

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_685a41567b1483208d1deea6c1f37879