### PR TITLE
Fix assignment notification for missing authUserId

### DIFF
--- a/server/routes/assignments.ts
+++ b/server/routes/assignments.ts
@@ -82,13 +82,16 @@ export function registerAssignmentRoutes(app: Express, { authenticateUser, requi
 
       const students = await getStorage().getStudentsBySubject(assignmentData.subjectId);
       for (const student of students) {
-        await getStorage().createNotification({
-          userId: student.authUserId,
-          title: "New Assignment",
-          content: `A new assignment "${assignment.title}" has been posted for ${assignment.subjectId}.`,
-          relatedId: assignment.id,
-          relatedType: "assignment"
-        });
+        // Send notification only if the student has an authUserId
+        if (student.authUserId) {
+          await getStorage().createNotification({
+            userId: student.authUserId,
+            title: "New Assignment",
+            content: `A new assignment "${assignment.title}" has been posted for ${assignment.subjectId}.`,
+            relatedId: assignment.id,
+            relatedType: "assignment"
+          });
+        }
       }
 
       res.status(201).json(assignment);


### PR DESCRIPTION
## Summary
- ensure notifications are only created for students with authUserId

## Testing
- `npm run check`
- `node --test` *(fails: cannot find module '/workspace/CampusConnect/server/utils/logger' imported from curriculum-weeks.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_685a442be8c88320b71cf4efff96748f