### PR TITLE
Update React Query cache option

### DIFF
--- a/client/src/hooks/useNotifications.ts
+++ b/client/src/hooks/useNotifications.ts
@@ -22,7 +22,7 @@ export function useNotifications() {
     refetchIntervalInBackground: false,
     refetchOnWindowFocus: true,
     staleTime: 0,
-    cacheTime: 1000 * 60 * 2,
+    gcTime: 1000 * 60 * 2,
   });
 
   // Mark a single notification as read

--- a/client/src/lib/queryClient.ts
+++ b/client/src/lib/queryClient.ts
@@ -153,7 +153,7 @@ export const queryClient = new QueryClient({
     queries: {
       queryFn: getQueryFn({ on401: "throw" }),
       staleTime: 0,
-      cacheTime: 1000 * 60 * 5,
+      gcTime: 1000 * 60 * 5,
       refetchOnWindowFocus: true,
       refetchOnMount: true,
       refetchOnReconnect: true,


### PR DESCRIPTION
## Summary
- migrate deprecated `cacheTime` option to `gcTime`

## Testing
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_685a48deb8348320a36300c35d6255aa