### PR TITLE
Add completed status to TaskStatus enum

### DIFF
--- a/client/src/pages/tasks/useTasks.ts
+++ b/client/src/pages/tasks/useTasks.ts
@@ -29,7 +29,7 @@ const taskFormSchema = z.object({
   title: z.string().min(1),
   description: z.string().optional(),
   priority: z.enum(['high', 'medium', 'low']),
-  status: z.enum(['new', 'in_progress', 'on_hold']),
+  status: z.enum(['new', 'in_progress', 'on_hold', 'completed']),
   executorId: z.string(),
   dueDate: z.date().nullable().optional(),
 });


### PR DESCRIPTION
## Summary
- extend task status schema in the tasks page to accept `completed`

## Testing
- `npx tsc --noEmit` *(fails: ~58 TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_685a5f5e4b94832097e8677286b08b8a