### PR TITLE
Remove obsolete mock requests

### DIFF
--- a/server/auth.ts
+++ b/server/auth.ts
@@ -12,61 +12,6 @@ import { testConnection } from "./db/index";
 // Import storage helpers and interface
 import { IStorage, setStorage, getStorage, DatabaseStorage } from "./storage";
 
-export const mockData: { requests: SelectRequest[]; users: any[] } = {
-  requests: [
-    {
-      id: 1,
-      studentId: 1,
-      type: "general",
-      description: "Example request 1",
-      status: "pending",
-      createdAt: new Date(),
-      resolvedBy: null,
-      resolvedAt: null,
-      resolution: null,
-    },
-    {
-      id: 2,
-      studentId: 2,
-      type: "financial",
-      description: "Example request 2",
-      status: "approved",
-      createdAt: new Date(),
-      resolvedBy: 1,
-      resolvedAt: new Date(),
-      resolution: "Approved",
-    },
-  ],
-  users: [
-    {
-      id: 1,
-      first_name: 'petr',
-      last_name: 'petrovich',
-      email: 'petr@example.com',
-      role: 'student',
-      password: 'mock',
-      created_at: new Date(),
-    },
-    {
-      id: 2,
-      first_name: 'Vadim',
-      last_name: 'Fertik',
-      email: 'vadim@example.com',
-      role: 'admin',
-      password: 'mock',
-      created_at: new Date(),
-    },
-    {
-      id: 3,
-      first_name: '',
-      last_name: '',
-      email: 'unknown@example.com',
-      role: 'student',
-      password: 'mock',
-      created_at: new Date(),
-    },
-  ],
-};
 
 declare global {
   namespace Express {
@@ -267,14 +212,14 @@ export const authRoutes = {
         .order('created_at', { ascending: false });
 
       if (error) {
-        logger.warn('Requests fetch error, returning mock data:', error);
-        return res.json(mockData.requests);
+        logger.error('Requests fetch error:', error);
+        return res.status(500).json({ message: 'Failed to fetch requests' });
       }
 
-      return res.json(data || mockData.requests);
+      return res.json(data || []);
     } catch (error) {
       logger.error('Error in /api/requests:', error);
-      return res.json(mockData.requests);
+      return res.status(500).json({ message: 'Failed to fetch requests' });
     }
   },
 };

--- a/server/routes/users.ts
+++ b/server/routes/users.ts
@@ -5,7 +5,6 @@ import { z } from "zod";
 import type { RouteContext } from "./index";
 import { logger } from "../utils/logger";
 import { supabase } from "../supabaseClient";
-import { mockData } from "../auth";
 import { db } from "../db/index";
 import * as schema from "@shared/schema";
 import { getDbUserBySupabaseUser } from "../utils/userMapping";
@@ -38,13 +37,7 @@ export function registerUserRoutes(app: Express, { authenticateUser, requireRole
       return res.json(users);
     } catch (error) {
       logger.error('Error in /api/users:', error);
-      const formattedMockUsers = mockData.users.map(user => ({
-        id: user.id,
-        firstName: user.first_name,
-        lastName: user.last_name,
-        role: user.role,
-      }));
-      return res.json(formattedMockUsers);
+      return res.status(500).json({ message: 'Failed to fetch users' });
     }
   });
 


### PR DESCRIPTION
## Summary
- delete unused user mock data
- remove fallback to mock users in user routes

## Testing
- `npx tsc --noEmit` *(fails: multiple type errors)*

------
https://chatgpt.com/codex/tasks/task_e_685a6355286483209ebae4b1edeb3672