### PR TITLE
Fix types for map/filter in Users page

### DIFF
--- a/client/src/pages/users/Users.tsx
+++ b/client/src/pages/users/Users.tsx
@@ -207,7 +207,7 @@ export default function Users() {
 
 
   // Filter users based on search query and role filter
-  const filteredUsers = users.filter(user => {
+  const filteredUsers = users.filter((user: User) => {
     const matchesSearch = 
       searchQuery === '' || 
       user.firstName.toLowerCase().includes(searchQuery.toLowerCase()) ||
@@ -476,7 +476,7 @@ export default function Users() {
                   </TableRow>
                 </TableHeader>
                 <TableBody>
-                  {currentUsers.map((user) => (
+                  {currentUsers.map((user: User) => (
                     <TableRow 
                       key={user.id} 
                       className="cursor-pointer hover:bg-secondary/50"


### PR DESCRIPTION
## Summary
- add explicit `User` type annotations to fix implicit `any` errors

## Testing
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_685a682020288320b3e58f2352a9b5be