### PR TITLE
Update route parameter types

### DIFF
--- a/server/routes/activityLogs.ts
+++ b/server/routes/activityLogs.ts
@@ -33,7 +33,7 @@ export function registerActivityLogRoutes(app: Express, { authenticateUser, requ
     authenticateUser,
     requireRole(['admin']),
     asyncHandler(async (req, res) => {
-      const userId = parseInt(req.params.userId);
+      const userId = req.params.userId;
       const limit = req.query.limit ? parseInt(req.query.limit as string) : 10;
       const logs = await getStorage().getActivityLogsByUser(userId, limit);
       res.json(logs);

--- a/server/routes/assignments.ts
+++ b/server/routes/assignments.ts
@@ -17,7 +17,7 @@ export function registerAssignmentRoutes(app: Express, { authenticateUser, requi
 
   app.get('/api/assignments/:id', authenticateUser, async (req, res) => {
     try {
-      const assignmentId = parseInt(req.params.id);
+      const assignmentId = req.params.id;
       const assignment = await getStorage().getAssignment(assignmentId);
 
       if (!assignment) {
@@ -102,7 +102,7 @@ export function registerAssignmentRoutes(app: Express, { authenticateUser, requi
 
   app.put('/api/assignments/:id', authenticateUser, requireRole(['admin', 'teacher']), async (req, res) => {
     try {
-      const assignmentId = parseInt(req.params.id);
+      const assignmentId = req.params.id;
       const assignment = await getStorage().getAssignment(assignmentId);
 
       if (!assignment) {
@@ -127,7 +127,7 @@ export function registerAssignmentRoutes(app: Express, { authenticateUser, requi
 
   app.delete('/api/assignments/:id', authenticateUser, requireRole(['admin', 'teacher']), async (req, res) => {
     try {
-      const assignmentId = parseInt(req.params.id);
+      const assignmentId = req.params.id;
       const assignment = await getStorage().getAssignment(assignmentId);
 
       if (!assignment) {
@@ -148,7 +148,7 @@ export function registerAssignmentRoutes(app: Express, { authenticateUser, requi
   // Submission Routes
   app.get('/api/submissions/assignment/:assignmentId', authenticateUser, async (req, res) => {
     try {
-      const assignmentId = parseInt(req.params.assignmentId);
+      const assignmentId = req.params.assignmentId;
 
       const assignment = await getStorage().getAssignment(assignmentId);
       if (!assignment) {
@@ -188,7 +188,7 @@ export function registerAssignmentRoutes(app: Express, { authenticateUser, requi
 
   app.post('/api/submissions', authenticateUser, requireRole(['student']), upload.single('file'), async (req, res) => {
     try {
-      const assignmentId = parseInt(req.body.assignmentId);
+      const assignmentId = req.body.assignmentId;
       const studentId = req.user!.id;
 
       const assignment = await getStorage().getAssignment(assignmentId);
@@ -242,7 +242,7 @@ export function registerAssignmentRoutes(app: Express, { authenticateUser, requi
 
   app.put('/api/submissions/:id/grade', authenticateUser, requireRole(['admin', 'teacher']), async (req, res) => {
     try {
-      const submissionId = parseInt(req.params.id);
+      const submissionId = req.params.id;
       const { grade, feedback } = req.body;
 
       const submission = await getStorage().getSubmission(submissionId);
@@ -309,7 +309,7 @@ export function registerAssignmentRoutes(app: Express, { authenticateUser, requi
 
   app.get('/api/grades/subject/:subjectId', authenticateUser, requireRole(['admin', 'teacher']), async (req, res) => {
     try {
-      const subjectId = parseInt(req.params.subjectId);
+      const subjectId = req.params.subjectId;
 
       if (req.user!.role === 'teacher') {
         const subject = await getStorage().getSubject(subjectId);
@@ -357,7 +357,7 @@ export function registerAssignmentRoutes(app: Express, { authenticateUser, requi
 
   app.put('/api/grades/:id', authenticateUser, requireRole(['admin', 'teacher']), async (req, res) => {
     try {
-      const gradeId = parseInt(req.params.id);
+      const gradeId = req.params.id;
       const grade = await getStorage().getGrade(gradeId);
 
       if (!grade) {

--- a/server/routes/curriculum.ts
+++ b/server/routes/curriculum.ts
@@ -60,10 +60,7 @@ export function registerCurriculumRoutes(app: Express, { authenticateUser, requi
 
   app.get('/api/curriculum-plans/:id', authenticateUser, async (req, res) => {
     try {
-      const planId = parseInt(req.params.id);
-      if (isNaN(planId)) {
-        return res.status(400).json({ message: "Invalid curriculum plan ID", details: "Curriculum plan ID must be a valid number" });
-      }
+      const planId = req.params.id;
       const storage = getStorage();
       let plan: any = null;
       if (typeof storage.getCurriculumPlan === 'function') {
@@ -110,10 +107,7 @@ export function registerCurriculumRoutes(app: Express, { authenticateUser, requi
 
   const updateCurriculumPlan = async (req: any, res: any) => {
     try {
-      const planId = parseInt(req.params.id);
-      if (isNaN(planId)) {
-        return res.status(400).json({ message: "Invalid curriculum plan ID", details: "Curriculum plan ID must be a valid number" });
-      }
+      const planId = req.params.id;
       const plan = await getStorage().getCurriculumPlan(planId);
       if (!plan) {
         return res.status(404).json({ message: "Curriculum plan not found", details: `No curriculum plan exists with ID ${planId}` });
@@ -154,10 +148,7 @@ export function registerCurriculumRoutes(app: Express, { authenticateUser, requi
 
   app.delete('/api/curriculum-plans/:id', authenticateUser, requireRole(['admin']), async (req, res) => {
     try {
-      const planId = parseInt(req.params.id);
-      if (isNaN(planId)) {
-        return res.status(400).json({ message: "Invalid curriculum plan ID", details: "Curriculum plan ID must be a valid number" });
-      }
+      const planId = req.params.id;
       const plan = await getStorage().getCurriculumPlan(planId);
       if (!plan) {
         return res.status(404).json({ message: "Curriculum plan not found", details: `No curriculum plan exists with ID ${planId}` });
@@ -182,7 +173,7 @@ export function registerCurriculumRoutes(app: Express, { authenticateUser, requi
 
   app.get('/api/documents', authenticateUser, async (req, res) => {
     try {
-      const userId = req.query.userId ? parseInt(req.query.userId as string) : undefined;
+      const userId = req.query.userId ? (req.query.userId as string) : undefined;
       res.json([]);
     } catch (error) {
       logger.error('Error getting documents:', error);
@@ -196,10 +187,7 @@ export function registerCurriculumRoutes(app: Express, { authenticateUser, requi
       if (!planId) {
         return res.status(400).json({ message: "Missing plan ID", details: "A planId is required" });
       }
-      const id = parseInt(planId);
-      if (isNaN(id)) {
-        return res.status(400).json({ message: "Invalid plan ID", details: "Plan ID must be a valid number" });
-      }
+      const id = planId;
       const plan = await getStorage().getCurriculumPlan(id);
       if (!plan) {
         return res.status(404).json({ message: "Curriculum plan not found", details: `No plan found with ID ${id}` });

--- a/server/routes/documents.ts
+++ b/server/routes/documents.ts
@@ -11,7 +11,7 @@ export function registerDocumentRoutes(app: Express, { authenticateUser, require
     '/api/documents/user/:userId',
     authenticateUser,
     asyncHandler(async (req, res) => {
-      const userId = parseInt(req.params.userId);
+      const userId = req.params.userId;
       if (req.user!.id !== userId && req.user!.role === 'student') {
         return res.status(403).json({
           message: 'Forbidden',
@@ -27,7 +27,7 @@ export function registerDocumentRoutes(app: Express, { authenticateUser, require
     '/api/documents/user/:userId/type/:type',
     authenticateUser,
     asyncHandler(async (req, res) => {
-      const userId = parseInt(req.params.userId);
+      const userId = req.params.userId;
       const type = req.params.type;
       if (req.user!.id !== userId && req.user!.role === 'student') {
         return res.status(403).json({

--- a/server/routes/messages.ts
+++ b/server/routes/messages.ts
@@ -35,7 +35,7 @@ export function registerMessageRoutes(app: Express, { authenticateUser }: RouteC
       if (!req.user) {
         return res.status(401).json({ message: "Unauthorized" });
       }
-      const otherUserId = parseInt(req.params.userId);
+      const otherUserId = req.params.userId;
       const messages = await getStorage().getMessagesBetweenUsers(req.user!.id, otherUserId);
       res.json(messages);
     } catch {
@@ -78,7 +78,7 @@ export function registerMessageRoutes(app: Express, { authenticateUser }: RouteC
 
   // 🔍 [DEBUG] Log all registered routes for verification
   console.log('🔍 [DEBUG] All registered routes:');
-  (app as any)._router.stack.forEach((middleware, index) => {
+  (app as any)._router.stack.forEach((middleware, index: number) => {
     if (middleware.route) {
       console.log(`Route ${index}: ${middleware.route.path}`);
     }

--- a/server/routes/notifications.ts
+++ b/server/routes/notifications.ts
@@ -40,7 +40,7 @@ export function registerNotificationRoutes(app: Express, { authenticateUser, req
 
   app.delete('/api/notifications/:id', authenticateUser, async (req, res) => {
     try {
-      const notificationId = parseInt(req.params.id);
+      const notificationId = req.params.id;
       const notification = await getStorage().getNotification(notificationId);
       if (!notification) {
         return res.status(404).json({ message: "Notification not found" });
@@ -82,7 +82,7 @@ export function registerNotificationRoutes(app: Express, { authenticateUser, req
 
   app.patch('/api/notifications/:id/read', authenticateUser, async (req, res) => {
     try {
-      const notificationId = parseInt(req.params.id);
+      const notificationId = req.params.id;
       const notification = await getStorage().getNotification(notificationId);
       if (!notification) {
         return res.status(404).json({ message: "Notification not found" });

--- a/server/routes/requests.ts
+++ b/server/routes/requests.ts
@@ -61,7 +61,7 @@ export function registerRequestRoutes(app: Express, { authenticateUser, requireR
 
   app.put('/api/requests/:id/status', authenticateUser, requireRole(['admin', 'teacher']), async (req, res) => {
     try {
-      const requestId = parseInt(req.params.id);
+      const requestId = req.params.id;
       const { status, resolution } = req.body;
 
       if (!['approved', 'rejected'].includes(status)) {

--- a/server/routes/schedule.ts
+++ b/server/routes/schedule.ts
@@ -37,7 +37,7 @@ app.get('/api/subjects', authenticateUser, async (req, res) => {
 
 app.get('/api/subjects/:id', authenticateUser, async (req, res) => {
   try {
-    const subjectId = parseInt(req.params.id);
+    const subjectId = req.params.id;
     const subject = await getStorage().getSubject(subjectId);
     
     if (!subject) {
@@ -102,7 +102,7 @@ app.post('/api/subjects', authenticateUser, requireRole(['admin']), async (req, 
 
 app.put('/api/subjects/:id', authenticateUser, requireRole(['admin']), async (req, res) => {
   try {
-    const subjectId = parseInt(req.params.id);
+    const subjectId = req.params.id;
     const subjectData = insertSubjectSchema.partial().parse(req.body);
     const updatedSubject = await getStorage().updateSubject(subjectId, subjectData);
     
@@ -121,7 +121,7 @@ app.put('/api/subjects/:id', authenticateUser, requireRole(['admin']), async (re
 
 app.delete('/api/subjects/:id', authenticateUser, requireRole(['admin']), async (req, res) => {
   try {
-    const subjectId = parseInt(req.params.id);
+    const subjectId = req.params.id;
     const success = await getStorage().deleteSubject(subjectId);
     
     if (!success) {
@@ -146,7 +146,7 @@ app.get('/api/enrollments', authenticateUser, requireRole(['admin', 'teacher']),
 
 app.get('/api/enrollments/student/:studentId', authenticateUser, async (req, res) => {
   try {
-    const studentId = parseInt(req.params.studentId);
+    const studentId = req.params.studentId;
     
     // Students can only view their own enrollments unless they're admins/teachers
     if (req.user!.id !== studentId && req.user!.role === 'student') {
@@ -162,7 +162,7 @@ app.get('/api/enrollments/student/:studentId', authenticateUser, async (req, res
 
 app.get('/api/enrollments/subject/:subjectId', authenticateUser, async (req, res) => {
   try {
-    const subjectId = parseInt(req.params.subjectId);
+    const subjectId = req.params.subjectId;
     const enrollments = await getStorage().getEnrollmentsBySubject(subjectId);
     res.json(enrollments);
   } catch (error) {
@@ -185,7 +185,7 @@ app.post('/api/enrollments', authenticateUser, requireRole(['admin']), async (re
 
 app.delete('/api/enrollments/:id', authenticateUser, requireRole(['admin']), async (req, res) => {
   try {
-    const enrollmentId = parseInt(req.params.id);
+    const enrollmentId = req.params.id;
     const success = await getStorage().deleteEnrollment(enrollmentId);
     
     if (!success) {
@@ -350,7 +350,7 @@ app.post('/api/schedule', authenticateUser, requireRole(['admin']), async (req, 
 
 app.put('/api/schedule/:id', authenticateUser, requireRole(['admin']), async (req, res) => {
   try {
-    const scheduleId = parseInt(req.params.id);
+    const scheduleId = req.params.id;
     const scheduleData = insertScheduleItemSchema.partial().parse(req.body);
     const updatedSchedule = await getStorage().updateScheduleItem(scheduleId, scheduleData);
     
@@ -369,7 +369,7 @@ app.put('/api/schedule/:id', authenticateUser, requireRole(['admin']), async (re
 
 app.delete('/api/schedule/:id', authenticateUser, requireRole(['admin']), async (req, res) => {
   try {
-    const scheduleId = parseInt(req.params.id);
+    const scheduleId = req.params.id;
     const success = await getStorage().deleteScheduleItem(scheduleId);
     
     if (!success) {
@@ -775,7 +775,7 @@ app.get('/api/imported-files', authenticateUser, requireRole(['admin']), async (
 
 app.get('/api/imported-files/:id', authenticateUser, requireRole(['admin']), async (req, res) => {
   try {
-    const id = parseInt(req.params.id);
+    const id = req.params.id;
     const file = await getStorage().getImportedFile(id);
     
     if (!file) {
@@ -790,7 +790,7 @@ app.get('/api/imported-files/:id', authenticateUser, requireRole(['admin']), asy
 
 app.get('/api/imported-files/user/:userId', authenticateUser, requireRole(['admin']), async (req, res) => {
   try {
-    const userId = parseInt(req.params.userId);
+    const userId = req.params.userId;
     const files = await getStorage().getImportedFilesByUser(userId);
     res.json(files);
   } catch (error) {
@@ -815,15 +815,8 @@ app.get('/api/imported-files/type/:type', authenticateUser, requireRole(['admin'
 
 app.delete('/api/imported-files/:id', authenticateUser, requireRole(['admin']), async (req, res) => {
   try {
-    const id = parseInt(req.params.id);
-    if (isNaN(id)) {
-      logger.error('Invalid file ID provided:', req.params.id);
-      return res.status(400).json({ 
-        error: true,
-        message: "Invalid file ID", 
-        details: "The file ID must be a valid number"
-      });
-    }
+    const id = req.params.id;
+
     
     logger.info(`[DELETE FILE] Processing delete request for imported file ID: ${id}`);
     

--- a/server/routes/tasks.ts
+++ b/server/routes/tasks.ts
@@ -218,7 +218,7 @@ app.post('/api/tasks', authenticateUser, async (req, res) => {
 // Endpoint для удаления задачи
 app.delete('/api/tasks/:id', authenticateUser, async (req, res) => {
   try {
-    const taskId = parseInt(req.params.id);
+    const taskId = req.params.id;
     const task = await getStorage().getTask(taskId);
     
     if (!task) {
@@ -285,7 +285,7 @@ app.delete('/api/tasks/:id', authenticateUser, async (req, res) => {
 
 app.put('/api/tasks/:id', authenticateUser, async (req, res) => {
   try {
-    const taskId = parseInt(req.params.id);
+    const taskId = req.params.id;
     const task = await getStorage().getTask(taskId);
     
     if (!task) {
@@ -401,14 +401,7 @@ app.put('/api/tasks/:id', authenticateUser, async (req, res) => {
 // чтобы избежать конфликтов с маршрутами tasks/client, tasks/executor и т.д.
 app.get('/api/tasks/:id', authenticateUser, async (req, res) => {
   try {
-    const taskId = parseInt(req.params.id);
-    
-    if (isNaN(taskId)) {
-      return res.status(400).json({
-        message: "Invalid task ID",
-        details: "Task ID must be a valid number"
-      });
-    }
+    const taskId = req.params.id;
     
     const task = await getStorage().getTask(taskId);
     
@@ -497,7 +490,7 @@ app.get('/api/users/:id/notifications', authenticateUser, async (req, res) => {
 // PATCH /api/tasks/:id/status - обновить статус задачи
 app.patch('/api/tasks/:id/status', authenticateUser, async (req, res) => {
   try {
-    const taskId = parseInt(req.params.id);
+    const taskId = req.params.id;
     const { status } = req.body;
     
     if (!status || !['new', 'in_progress', 'completed', 'on_hold'].includes(status)) {

--- a/server/routes/users.ts
+++ b/server/routes/users.ts
@@ -43,7 +43,7 @@ export function registerUserRoutes(app: Express, { authenticateUser, requireRole
 
 app.get('/api/users/:id', authenticateUser, async (req, res) => {
   try {
-    const userId = parseInt(req.params.id);
+    const userId = req.params.id;
     
     // Users can only view their own profile unless they're admins
     if (req.user!.id !== userId && req.user!.role !== 'admin') {
@@ -98,7 +98,7 @@ app.post('/api/users', authenticateUser, requireRole(['admin']), async (req, res
 
 app.put('/api/users/:id', authenticateUser, requireRole(['admin']), async (req, res) => {
   try {
-    const userId = parseInt(req.params.id);
+    const userId = req.params.id;
     logger.info(`🔄 PUT /api/users/${userId} - Updating user profile. Admin ID: ${req.user?.id}`);
     
     const userData = insertUserSchema.partial().parse(req.body);
@@ -195,7 +195,7 @@ app.put('/api/users/:id', authenticateUser, requireRole(['admin']), async (req, 
 
 app.delete('/api/users/:id', authenticateUser, requireRole(['admin']), async (req, res) => {
   try {
-    const userId = parseInt(req.params.id);
+    const userId = req.params.id;
     const success = await getStorage().deleteUser(userId);
     
     if (!success) {


### PR DESCRIPTION
## Summary
- treat Express route parameters as string IDs
- adjust comparisons for string UUIDs
- annotate middleware forEach index in messages route
- run TypeScript checks

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_685aaa344e2c832090c7091acfb2327f