### PR TITLE
Remove explicit notification timestamp

### DIFF
--- a/server/db/notifications.ts
+++ b/server/db/notifications.ts
@@ -40,7 +40,6 @@ export async function createNotification(notificationData: InsertNotification): 
       ...notificationData,
       userId: notificationData.userId,
       isRead: false,
-      createdAt: new Date(),
     })
     .returning();
   return notification;

--- a/server/services/NotificationService.ts
+++ b/server/services/NotificationService.ts
@@ -21,7 +21,6 @@ export class NotificationService {
         type: data.type ?? 'system',
         relatedId: data.relatedId,
         relatedType: data.relatedType,
-        createdAt: new Date(),
       });
       logger.info(`[INFO] Notification created: ${notification.title} for user ${data.userId}`);
       return notification;


### PR DESCRIPTION
## Summary
- rely on DB default for notification timestamps

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_685aae89c2808320a6168a9a9ad790c0