### PR TITLE
Switch student IDs to strings

### DIFF
--- a/client/src/components/requests/RequestList.tsx
+++ b/client/src/components/requests/RequestList.tsx
@@ -48,13 +48,13 @@ const RequestList: React.FC<RequestListProps> = ({
   }, [error, toast, t]);
   
   const getStudentName = (studentId: string) => {
-    const student = users.find(user => user.authUserId === studentId);
+    const student = users.find(user => user.id === studentId);
     return student ? `${student.firstName} ${student.lastName}` : `Student ID: ${studentId}`;
   };
 
   const getResolverName = (userId: string | null) => {
     if (!userId) return 'N/A';
-    const user = users.find(user => user.authUserId === userId);
+    const user = users.find(user => user.id === userId);
     return user ? `${user.firstName} ${user.lastName}` : `User ID: ${userId}`;
   };
   

--- a/client/src/components/students/EditStudentProfileModal.tsx
+++ b/client/src/components/students/EditStudentProfileModal.tsx
@@ -29,7 +29,7 @@ import { Button } from '@/components/ui/button';
 
 // Интерфейс для данных студента
 interface StudentProfile {
-  id: number;
+  id: string;
   firstName: string;
   lastName: string;
   email: string;

--- a/client/src/components/students/StudentCard.tsx
+++ b/client/src/components/students/StudentCard.tsx
@@ -33,7 +33,7 @@ import EditStudentProfileModal from './EditStudentProfileModal';
 
 // Интерфейс для данных студента
 export interface Student {
-  id: number;
+  id: string;
   firstName: string;
   lastName: string;
   email: string;
@@ -65,7 +65,7 @@ export interface UpcomingLesson {
 
 interface StudentCardProps {
   student: Student;
-  onClick?: (id: number) => void;
+  onClick?: (id: string) => void;
 }
 
 /**

--- a/client/src/components/students/StudentExample.tsx
+++ b/client/src/components/students/StudentExample.tsx
@@ -4,7 +4,7 @@ import { useToast } from '@/hooks/use-toast';
 
 // Пример данных студента для тестирования
 const mockStudent: Student = {
-  id: 1,
+  id: '1',
   firstName: 'Алексей',
   lastName: 'Иванов',
   email: 'alexey.ivanov@example.com',
@@ -23,7 +23,7 @@ const mockStudent: Student = {
 
 // Второй студент для демонстрации вариантов
 const mockStudent2: Student = {
-  id: 2,
+  id: '2',
   firstName: 'Екатерина',
   lastName: 'Смирнова',
   email: 'kat.smirnova@example.com',
@@ -40,7 +40,7 @@ const mockStudent2: Student = {
 
 // Пример студента с низкой успеваемостью
 const mockStudent3: Student = {
-  id: 3,
+  id: '3',
   firstName: 'Дмитрий',
   lastName: 'Петров',
   email: 'dima.petrov@example.com',
@@ -59,7 +59,7 @@ const mockStudent3: Student = {
 const StudentExample: React.FC = () => {
   const { toast } = useToast();
 
-  const handleStudentClick = (id: number) => {
+  const handleStudentClick = (id: string) => {
     toast({
       title: 'Студент выбран',
       description: `Вы выбрали студента с ID: ${id}`,

--- a/client/src/pages/documents/DocumentPage.tsx
+++ b/client/src/pages/documents/DocumentPage.tsx
@@ -229,7 +229,7 @@ export default function DocumentPage({ documentType, title, icon: Icon }: Docume
                   <CardContent>
                     <p className="text-sm text-neutral-500">{documentType === 'invoice' ? 'Created' : 'Issued'}: {formatDate(document.createdAt)}</p>
                     {isAdmin && (
-                      <p className="text-sm text-neutral-500">For: {users.find(u => u.authUserId === document.userId)?.firstName} {users.find(u => u.authUserId === document.userId)?.lastName}</p>
+                      <p className="text-sm text-neutral-500">For: {users.find(u => u.id === document.userId)?.firstName} {users.find(u => u.id === document.userId)?.lastName}</p>
                     )}
                   </CardContent>
                   <CardFooter className="flex justify-end">


### PR DESCRIPTION
## Summary
- change `Student` interfaces to use `id: string`
- adjust example data and click handler types
- update references in EditStudentProfileModal
- update RequestList and DocumentPage to look up users by `id`

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_685aafbaa7a08320be1b8a70eabb427a