### PR TITLE
Remove legacy auth user id

### DIFF
--- a/client/src/components/requests/RequestList.tsx
+++ b/client/src/components/requests/RequestList.tsx
@@ -48,13 +48,13 @@ const RequestList: React.FC<RequestListProps> = ({
   }, [error, toast, t]);
   
   const getStudentName = (studentId: string) => {
-    const student = users.find(user => user.authUserId === studentId);
+    const student = users.find(user => user.id === studentId);
     return student ? `${student.firstName} ${student.lastName}` : `Student ID: ${studentId}`;
   };
 
   const getResolverName = (userId: string | null) => {
     if (!userId) return 'N/A';
-    const user = users.find(user => user.authUserId === userId);
+    const user = users.find(user => user.id === userId);
     return user ? `${user.firstName} ${user.lastName}` : `User ID: ${userId}`;
   };
   

--- a/client/src/pages/documents/DocumentPage.tsx
+++ b/client/src/pages/documents/DocumentPage.tsx
@@ -229,7 +229,7 @@ export default function DocumentPage({ documentType, title, icon: Icon }: Docume
                   <CardContent>
                     <p className="text-sm text-neutral-500">{documentType === 'invoice' ? 'Created' : 'Issued'}: {formatDate(document.createdAt)}</p>
                     {isAdmin && (
-                      <p className="text-sm text-neutral-500">For: {users.find(u => u.authUserId === document.userId)?.firstName} {users.find(u => u.authUserId === document.userId)?.lastName}</p>
+                      <p className="text-sm text-neutral-500">For: {users.find(u => u.id === document.userId)?.firstName} {users.find(u => u.id === document.userId)?.lastName}</p>
                     )}
                   </CardContent>
                   <CardFooter className="flex justify-end">

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -188,18 +188,18 @@ export function setupAuth(app: Express) {
     const { data: publicUser, error } = await supabase
       .from("users")
       .select("*")
-      .eq("auth_user_id", authUser.id)
+      .eq("id", authUser.id)
       .single();
 
     res.json({
-      auth_user_exists: !!authUser,
-      auth_user_id: authUser.id,
-      auth_user_email: authUser.email,
-      auth_user_metadata: authUser.user_metadata,
+      user_exists: !!authUser,
+      user_id: authUser.id,
+      user_email: authUser.email,
+      user_metadata: authUser.user_metadata,
       public_user_exists: !!publicUser,
       public_user_data: publicUser,
-    error: error?.message
-  });
+      error: error?.message,
+    });
   });
 }
 

--- a/server/utils/userMapping.ts
+++ b/server/utils/userMapping.ts
@@ -2,32 +2,21 @@ import { getStorage } from '../storage';
 import { logger } from './logger';
 import type { User } from '@supabase/supabase-js';
 
-export async function getDbUserBySupabaseUser(supabaseUser: Pick<User, 'email' | 'id'>) {
-  console.log('🔍 [DEBUG] getDbUserBySupabaseUser called with:', {
-    email: supabaseUser.email,
-    id: supabaseUser.id
-  });
-
-  const email = supabaseUser.email;
-  if (!email) {
-    console.log('❌ [ERROR] No email found');
+export async function getDbUserBySupabaseUser(
+  supabaseUser: Pick<User, 'email' | 'id'>
+) {
+  if (!supabaseUser.email) {
     throw new Error('User email not found');
   }
 
   try {
-    const user = await getStorage().getUserByEmail(email);
-    console.log('🔍 [DEBUG] getUserByEmail result:', user ? {
-      id: user.id,
-      email: user.email,
-      role: user.role
-    } : 'null');
+    const user = await getStorage().getUserByEmail(supabaseUser.email);
 
     if (!user) {
-      console.log('❌ [ERROR] User not found in database');
       throw new Error('User not found in database');
     }
 
-    const result = {
+    return {
       id: user.id,
       firstName: user.firstName,
       lastName: user.lastName,
@@ -36,11 +25,7 @@ export async function getDbUserBySupabaseUser(supabaseUser: Pick<User, 'email' |
       createdAt: (user as any).createdAt,
       updatedAt: (user as any).updatedAt,
     };
-
-    console.log('✅ [SUCCESS] userMapping result:', result);
-    return result;
   } catch (error) {
-    console.log('🚨 [ERROR] userMapping error:', error);
     logger.error('User mapping error:', error);
     throw error;
   }


### PR DESCRIPTION
## Summary
- drop `auth_user_id` lookups in auth debug handler
- simplify `getDbUserBySupabaseUser`
- update request and document components to use `id` instead of `authUserId`

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_685aafc77b2883208344a5f5d1571700