### PR TITLE
Fix data seeding with UUID references

### DIFF
--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1162,7 +1162,7 @@ export class MemStorage implements IStorage {
     // Создаем новый курс
     return this.createCourse({
       number,
-      specialtyId: Number(specialtyId),
+      specialtyId,
       academicYear
     });
   }
@@ -1180,7 +1180,7 @@ export class MemStorage implements IStorage {
     // Создаем новую группу
     return this.createGroup({
       name,
-      courseId: Number(courseId)
+      courseId
     });
   }
   
@@ -1537,52 +1537,52 @@ export class MemStorage implements IStorage {
     // Создаем курсы
     const cs1 = this.createCourse({
       number: 1,
-      specialtyId: 1, // Информатика, 1-й курс
+      specialtyId: computerScience.id, // Информатика, 1-й курс
       academicYear: "2024-2025"
     });
     
     const cs2 = this.createCourse({
       number: 2,
-      specialtyId: 1, // Информатика, 2-й курс
+      specialtyId: computerScience.id, // Информатика, 2-й курс
       academicYear: "2024-2025"
     });
     
     const econ1 = this.createCourse({
       number: 1,
-      specialtyId: 2, // Экономика, 1-й курс
+      specialtyId: economics.id, // Экономика, 1-й курс
       academicYear: "2024-2025"
     });
     
     const swe1 = this.createCourse({
       number: 1,
-      specialtyId: 3, // Программная инженерия, 1-й курс
+      specialtyId: softwareEngineering.id, // Программная инженерия, 1-й курс
       academicYear: "2024-2025"
     });
     
     // Создаем группы
     const csGroup1 = this.createGroup({
       name: "ИВТ-101",
-      courseId: 1 // Информатика, 1-й курс
+      courseId: cs1.id // Информатика, 1-й курс
     });
     
     const csGroup2 = this.createGroup({
       name: "ИВТ-102",
-      courseId: 1 // Информатика, 1-й курс
+      courseId: cs1.id // Информатика, 1-й курс
     });
     
     const csGroup3 = this.createGroup({
       name: "ИВТ-201",
-      courseId: 2 // Информатика, 2-й курс
+      courseId: cs2.id // Информатика, 2-й курс
     });
     
     const econGroup1 = this.createGroup({
       name: "ЭКО-101",
-      courseId: 3 // Экономика, 1-й курс
+      courseId: econ1.id // Экономика, 1-й курс
     });
     
     const sweGroup1 = this.createGroup({
       name: "ПИ-101",
-      courseId: 4 // Программная инженерия, 1-й курс
+      courseId: swe1.id // Программная инженерия, 1-й курс
     });
     
     // Создаем тестовые учебные планы

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -205,7 +205,7 @@ export const activityLogs = pgTable("activity_logs", {
   description: text("description").notNull(),
   userId: uuid("user_id").references(() => users.id).notNull(), // Who performed the action
   timestamp: timestamp("timestamp").defaultNow(),
-  entityId: integer("entity_id"), // ID of the affected entity (file, user, subject, etc.)
+  entityId: uuid("entity_id"), // ID of the affected entity (file, user, subject, etc.)
   entityType: text("entity_type"), // Type of the affected entity
   metadata: text("metadata"), // JSON string with additional data if needed
 });


### PR DESCRIPTION
## Summary
- use IDs from created specialties/courses when seeding
- remove number casting in course and group creation helpers
- store entityId in activityLogs as UUID

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_685ae158ab3c8320ac74a9bb429423df