### PR TITLE
Fix relatedId type in NotificationService

### DIFF
--- a/server/services/NotificationService.ts
+++ b/server/services/NotificationService.ts
@@ -3,7 +3,7 @@ export interface CreateNotificationData {
   title: string;
   message: string;
   type?: 'task_update' | 'task_assigned' | 'system' | 'reminder';
-  relatedId?: number;
+  relatedId?: string;
   relatedType?: 'task' | 'user' | 'project';
 }
 


### PR DESCRIPTION
## Summary
- use string UUID for `relatedId` in `CreateNotificationData`

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_685ae43923088320ac74da326b6bea55