### PR TITLE
Fix uuid handling in client components

### DIFF
--- a/client/src/components/grades/GradeForm.tsx
+++ b/client/src/components/grades/GradeForm.tsx
@@ -33,7 +33,7 @@ const GradeForm: React.FC<GradeFormProps> = ({ students, subjects, onSubmit }) =
     resolver: zodResolver(gradeFormSchema),
     defaultValues: {
       studentId: '',
-      subjectId: 0,
+      subjectId: '',
       assignmentId: null,
       score: 0,
       maxScore: 100,
@@ -101,8 +101,8 @@ const GradeForm: React.FC<GradeFormProps> = ({ students, subjects, onSubmit }) =
                   <FormItem>
                     <FormLabel>Subject</FormLabel>
                     <Select
-                      onValueChange={(value) => field.onChange(parseInt(value))}
-                      defaultValue={field.value.toString()}
+                      onValueChange={field.onChange}
+                      defaultValue={field.value}
                     >
                       <FormControl>
                         <SelectTrigger>

--- a/client/src/components/grades/GradeList.tsx
+++ b/client/src/components/grades/GradeList.tsx
@@ -12,13 +12,13 @@ interface GradeListProps {
 
 const GradeList: React.FC<GradeListProps> = ({ grades, subjects }) => {
   // Helper function to find subject name by ID
-  const getSubjectName = (subjectId: number) => {
+  const getSubjectName = (subjectId: string) => {
     const subject = subjects.find(s => s.id === subjectId);
     return subject ? subject.name : `Subject ${subjectId}`;
   };
   
   // Group grades by subject
-  const gradesBySubject: Record<number, Grade[]> = {};
+  const gradesBySubject: Record<string, Grade[]> = {};
   
   grades.forEach(grade => {
     if (!gradesBySubject[grade.subjectId]) {
@@ -69,7 +69,7 @@ const GradeList: React.FC<GradeListProps> = ({ grades, subjects }) => {
             <Card key={subjectId}>
               <CardHeader className="flex flex-row items-center justify-between">
                 <CardTitle className="text-md font-heading">
-                  {getSubjectName(parseInt(subjectId))}
+                  {getSubjectName(subjectId)}
                 </CardTitle>
                 <div className={`text-lg font-bold ${getGpaColor(subjectGpa)}`}>
                   GPA: {subjectGpa}

--- a/client/src/pages/curriculum/EditCurriculumPlan.tsx
+++ b/client/src/pages/curriculum/EditCurriculumPlan.tsx
@@ -90,7 +90,7 @@ function calcEndYear(startYear: number, years: number, months: number = 0): numb
 // Компонент редактирования учебного плана
 function EditCurriculumPlanContent(): React.ReactNode {
   const { id } = useParams();
-  const planId = id ? parseInt(id) : NaN;
+  const planId = id || '';
   const [, navigate] = useLocation();
   const { toast } = useToast();
   const queryClient = useQueryClient();
@@ -136,14 +136,14 @@ function EditCurriculumPlanContent(): React.ReactNode {
   // Получаем данные о учебном плане
   const { data: plan, isLoading, error } = useQuery<CurriculumPlan>({
     queryKey: [`/api/curriculum-plans/${planId}`],
-    enabled: !isNaN(planId),
+    enabled: !!planId,
     refetchOnWindowFocus: false,
   });
 
   // Мутация для обновления учебного плана (унифицированная версия)
   const updateMutation = useMutation({
     mutationFn: (updatedPlan: Partial<CurriculumFormValues> & {
-      id: number,
+      id: string,
       calendarData?: string,
       curriculumPlanData?: string,
       // Новые поля для унифицированного сохранения
@@ -972,7 +972,7 @@ function EditCurriculumPlanContent(): React.ReactNode {
     navigate("/curriculum-plans");
   };
 
-  if (isNaN(planId)) {
+  if (!planId) {
     return (
       <Alert variant="destructive" className="mb-4">
         <AlertCircle className="h-4 w-4" />
@@ -1344,7 +1344,7 @@ function EditCurriculumPlanContent(): React.ReactNode {
                           planYear={plan.startYear || new Date().getFullYear()}
                           yearsOfStudy={planYearsOfStudy} // Используем локальное состояние вместо значения из плана
                           initialData={plan.calendarData ? JSON.parse(plan.calendarData as string) : {}}
-                          planId={planId.toString()} // Явно указываем planId из родительского компонента
+                          planId={planId} // Явно указываем planId из родительского компонента
                           autosavePaused={autosavePaused} // Передаем флаг паузы автосохранения
                           onChange={(data) => {
 
@@ -1430,7 +1430,7 @@ function EditCurriculumPlanContent(): React.ReactNode {
                   initialData={plan?.curriculumPlanData ? JSON.parse(plan.curriculumPlanData) : undefined}
                   onPlanChange={(planData) => {
                     // Сохраняем данные через единую функцию saveCurriculum
-                    if (planId && !isNaN(planId)) {
+                    if (planId) {
                       logger.info({
                         nodesCount: planData.length,
                         firstNode: planData[0]?.title || 'unknown',


### PR DESCRIPTION
## Summary
- use string IDs in GradeForm
- handle string-based subjects in GradeList
- switch curriculum plan page to expect string plan IDs

## Testing
- `npm run -s check`

------
https://chatgpt.com/codex/tasks/task_e_685ae59e74dc832098f8ea53f222a862