### PR TITLE
Fix id types for UUIDs across client components

### DIFF
--- a/client/src/components/assignments/AssignmentDetails.tsx
+++ b/client/src/components/assignments/AssignmentDetails.tsx
@@ -17,7 +17,7 @@ interface AssignmentDetailsProps {
   creator?: User;
   isTeacher: boolean;
   onSubmit: (formData: FormData) => Promise<any>;
-  onGrade?: (submissionId: number, grade: number, feedback: string) => Promise<any>;
+  onGrade?: (submissionId: string, grade: number, feedback: string) => Promise<any>;
 }
 
 const AssignmentDetails: React.FC<AssignmentDetailsProps> = ({

--- a/client/src/components/dashboards/StudentDashboard.tsx
+++ b/client/src/components/dashboards/StudentDashboard.tsx
@@ -123,7 +123,7 @@ const StudentDashboard = () => {
   })[0];
   
   // Mark notification as read
-  const handleMarkAsRead = async (id: number) => {
+  const handleMarkAsRead = async (id: string) => {
     await apiRequest(`/api/notifications/${id}/read`, 'PUT', {});
   };
   

--- a/client/src/components/dashboards/TeacherDashboard.tsx
+++ b/client/src/components/dashboards/TeacherDashboard.tsx
@@ -98,7 +98,7 @@ const TeacherDashboard = () => {
   });
   
   // Mark notification as read
-  const handleMarkAsRead = async (id: number) => {
+  const handleMarkAsRead = async (id: string) => {
     await apiRequest(`/api/notifications/${id}/read`, 'PUT', {});
   };
   

--- a/client/src/components/notifications/NotificationList.tsx
+++ b/client/src/components/notifications/NotificationList.tsx
@@ -14,7 +14,7 @@ import { cn } from '@/lib/utils';
 
 interface NotificationListProps {
   notifications: Notification[];
-  onMarkAsRead?: (id: number) => void;
+  onMarkAsRead?: (id: string) => void;
   onMarkAllAsRead?: () => void;
   onViewAll?: () => void;
 }

--- a/client/src/components/requests/RequestList.tsx
+++ b/client/src/components/requests/RequestList.tsx
@@ -14,7 +14,7 @@ interface RequestListProps {
   requests: Request[];
   users?: User[];
   isAdmin?: boolean;
-  onUpdateStatus?: (requestId: number, status: 'approved' | 'rejected', resolution: string) => Promise<void>;
+  onUpdateStatus?: (requestId: string, status: 'approved' | 'rejected', resolution: string) => Promise<void>;
   isLoading?: boolean;
   error?: Error | null;
   onRetry?: () => void;

--- a/client/src/pages/curriculum/CurriculumPlans.tsx
+++ b/client/src/pages/curriculum/CurriculumPlans.tsx
@@ -84,7 +84,7 @@ export default function CurriculumPlans() {
 
   // Мутация для обновления учебного плана
   const updateMutation = useMutation({
-    mutationFn: (updatedPlan: Partial<CurriculumFormValues> & { id: number }) => {
+    mutationFn: (updatedPlan: Partial<CurriculumFormValues> & { id: string }) => {
       const { id, ...planData } = updatedPlan;
       return apiRequest(`/api/curriculum-plans/${id}`, 'PUT', JSON.stringify(planData));
     },
@@ -109,7 +109,7 @@ export default function CurriculumPlans() {
 
   // Мутация для удаления учебного плана
   const deleteMutation = useMutation({
-    mutationFn: (id: number) =>
+    mutationFn: (id: string) =>
       apiRequest(`/api/curriculum-plans/${id}`, 'DELETE'),
     onSuccess: () => {
       toast({

--- a/client/src/pages/requests/Requests.tsx
+++ b/client/src/pages/requests/Requests.tsx
@@ -62,7 +62,7 @@ const Requests = () => {
   
   // Mutation for updating request status (admin/teacher)
   const updateRequestStatusMutation = useMutation({
-    mutationFn: ({ requestId, status, resolution }: { requestId: number; status: 'approved' | 'rejected'; resolution: string }) => {
+    mutationFn: ({ requestId, status, resolution }: { requestId: string; status: 'approved' | 'rejected'; resolution: string }) => {
       return putData(`/api/requests/${requestId}/status`, { status, resolution });
     },
     onSuccess: () => {
@@ -85,7 +85,7 @@ const Requests = () => {
     await createRequestMutation.mutateAsync(data);
   };
   
-  const handleUpdateRequestStatus = async (requestId: number, status: 'approved' | 'rejected', resolution: string) => {
+  const handleUpdateRequestStatus = async (requestId: string, status: 'approved' | 'rejected', resolution: string) => {
     await updateRequestStatusMutation.mutateAsync({ requestId, status, resolution });
   };
   


### PR DESCRIPTION
## Summary
- fix AssignmentDetails onGrade callback signature
- update dashboards to handle string IDs for notifications
- adjust NotificationList and RequestList props to expect string IDs
- update CurriculumPlans mutations to use string IDs
- align Requests page helpers with string-based IDs

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_685af00aeaf48320a2d8ccca14d7cad2