### PR TITLE
Fix server UUID parameter types

### DIFF
--- a/server/db/notifications.ts
+++ b/server/db/notifications.ts
@@ -7,10 +7,10 @@ export async function getNotifications(): Promise<Notification[]> {
   return db.select().from(schema.notifications);
 }
 
-export async function getNotification(id: number): Promise<Notification | undefined> {
+export async function getNotification(id: string): Promise<Notification | undefined> {
   const notifications = await db.select()
     .from(schema.notifications)
-    .where(eq(schema.notifications.id, id))
+    .where(eq(schema.notifications.id, String(id)))
     .limit(1);
   return notifications[0];
 }
@@ -45,17 +45,17 @@ export async function createNotification(notificationData: InsertNotification): 
   return notification;
 }
 
-export async function markNotificationAsRead(id: number): Promise<Notification | undefined> {
+export async function markNotificationAsRead(id: string): Promise<Notification | undefined> {
   const [notification] = await db.update(schema.notifications)
     .set({ isRead: true })
-    .where(eq(schema.notifications.id, id))
+    .where(eq(schema.notifications.id, String(id)))
     .returning();
   return notification;
 }
 
-export async function deleteNotification(id: number): Promise<boolean> {
+export async function deleteNotification(id: string): Promise<boolean> {
   const result = await db.delete(schema.notifications)
-    .where(eq(schema.notifications.id, id));
+    .where(eq(schema.notifications.id, String(id)));
   return (result.rowCount || 0) > 0;
 }
 

--- a/server/db/storage.ts
+++ b/server/db/storage.ts
@@ -47,8 +47,8 @@ export class SupabaseStorage {
     return this.usersRepo.getUsers();
   }
 
-  async getUser(id: number): Promise<User | undefined> {
-    return this.usersRepo.getUser(id);
+  async getUser(id: string): Promise<User | undefined> {
+    return this.usersRepo.getUser(String(id));
   }
 
   async getUserByEmail(email: string): Promise<User | undefined> {
@@ -64,12 +64,12 @@ export class SupabaseStorage {
     return this.usersRepo.createUser(userData);
   }
 
-  async updateUser(id: number, userData: Partial<InsertUser>): Promise<User | undefined> {
-    return this.usersRepo.updateUser(id, userData);
+  async updateUser(id: string, userData: Partial<InsertUser>): Promise<User | undefined> {
+    return this.usersRepo.updateUser(String(id), userData);
   }
 
-  async deleteUser(id: number): Promise<boolean> {
-    return this.usersRepo.deleteUser(id);
+  async deleteUser(id: string): Promise<boolean> {
+    return this.usersRepo.deleteUser(String(id));
   }
 
   async authenticate(credentials: LoginCredentials): Promise<User | undefined> {
@@ -91,8 +91,8 @@ export class SupabaseStorage {
     return this.subjectsRepo.getSubjects();
   }
 
-  async getSubject(id: number): Promise<Subject | undefined> {
-    return this.subjectsRepo.getSubject(id);
+  async getSubject(id: string): Promise<Subject | undefined> {
+    return this.subjectsRepo.getSubject(String(id));
   }
 
   async getSubjectsByTeacher(teacherId: string): Promise<Subject[]> {
@@ -103,12 +103,12 @@ export class SupabaseStorage {
     return this.subjectsRepo.createSubject(subjectData);
   }
 
-  async updateSubject(id: number, subjectData: Partial<InsertSubject>): Promise<Subject | undefined> {
-    return this.subjectsRepo.updateSubject(id, subjectData);
+  async updateSubject(id: string, subjectData: Partial<InsertSubject>): Promise<Subject | undefined> {
+    return this.subjectsRepo.updateSubject(String(id), subjectData);
   }
 
-  async deleteSubject(id: number): Promise<boolean> {
-    return this.subjectsRepo.deleteSubject(id);
+  async deleteSubject(id: string): Promise<boolean> {
+    return this.subjectsRepo.deleteSubject(String(id));
   }
 
   // Enrollments


### PR DESCRIPTION
## Summary
- fix notifications queries to accept string ID
- use string IDs when calling user and subject repositories

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_685b9cc250608320880ea886d1a7e2fb