### PR TITLE
Fix server route and util types

### DIFF
--- a/client/src/pages/assignments/AssignmentDetail.tsx
+++ b/client/src/pages/assignments/AssignmentDetail.tsx
@@ -75,7 +75,7 @@ const AssignmentDetail = () => {
   
   // Mutation for grading assignment (teacher)
   const gradeAssignmentMutation = useMutation({
-    mutationFn: ({ submissionId, grade, feedback }: { submissionId: number; grade: number; feedback: string }) => {
+    mutationFn: ({ submissionId, grade, feedback }: { submissionId: string; grade: number; feedback: string }) => {
       return putData(`/api/submissions/${submissionId}/grade`, { grade, feedback });
     },
     onSuccess: () => {
@@ -99,7 +99,7 @@ const AssignmentDetail = () => {
     await submitAssignmentMutation.mutateAsync(formData);
   };
   
-  const handleGrade = async (submissionId: number, grade: number, feedback: string) => {
+  const handleGrade = async (submissionId: string, grade: number, feedback: string) => {
     await gradeAssignmentMutation.mutateAsync({ submissionId, grade, feedback });
   };
   

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -195,7 +195,6 @@ export function setupAuth(app: Express) {
       user_exists: !!authUser,
       user_id: authUser.id,
       user_email: authUser.email,
-      user_metadata: authUser.user_metadata,
       public_user_exists: !!publicUser,
       public_user_data: publicUser,
       error: error?.message,

--- a/server/db/storage.ts
+++ b/server/db/storage.ts
@@ -661,7 +661,7 @@ export class SupabaseStorage {
     return notificationQueries.getNotifications();
   }
 
-  async getNotification(id: number): Promise<Notification | undefined> {
+  async getNotification(id: string): Promise<Notification | undefined> {
     return notificationQueries.getNotification(id);
   }
 
@@ -678,11 +678,11 @@ export class SupabaseStorage {
     return notificationQueries.createNotification(notificationData);
   }
 
-  async markNotificationAsRead(id: number): Promise<Notification | undefined> {
+  async markNotificationAsRead(id: string): Promise<Notification | undefined> {
     return notificationQueries.markNotificationAsRead(id);
   }
 
-  async deleteNotification(id: number): Promise<boolean> {
+  async deleteNotification(id: string): Promise<boolean> {
     return notificationQueries.deleteNotification(id);
   }
 

--- a/server/routes/curriculum.ts
+++ b/server/routes/curriculum.ts
@@ -82,7 +82,7 @@ export function registerCurriculumRoutes(app: Express, { authenticateUser, requi
   app.post('/api/curriculum-plans', authenticateUser, requireRole(['admin']), async (req, res) => {
     try {
       const { insertCurriculumPlanSchema } = await import('@shared/schema');
-      const modifiedSchema = insertCurriculumPlanSchema.extend({ createdBy: z.number().optional() });
+      const modifiedSchema = insertCurriculumPlanSchema.extend({ createdBy: z.string().uuid().optional() });
       const planData = modifiedSchema.parse(req.body);
       if (!planData.createdBy) {
         planData.createdBy = req.user!.id;

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -79,21 +79,21 @@ const authenticateUser = verifySupabaseJwt;
 
 
 // Вспомогательная функция для получения ID преподавателя по умолчанию
-async function getDefaultTeacherId(): Promise<number> {
+async function getDefaultTeacherId(): Promise<string> {
   try {
     // Пытаемся найти пользователя с ролью "teacher"
     const teachers = await getStorage().getUsersByRole('teacher');
     if (teachers && teachers.length > 0) {
       logger.info(`Found ${teachers.length} teachers, using ${teachers[0].firstName} ${teachers[0].lastName} (ID: ${teachers[0].id}) as default`);
-      return teachers[0].id;
+      return String(teachers[0].id);
     }
     
     // Если учителей нет, создаем тестового преподавателя
     logger.info('No teachers found, using fallback teacher ID 2');
-    return 2; // ID тестового преподавателя
+    return '2'; // ID тестового преподавателя
   } catch (error) {
     logger.error('Error getting default teacher:', error);
-    return 2; // В случае ошибки возвращаем ID тестового преподавателя
+    return '2'; // В случае ошибки возвращаем ID тестового преподавателя
   }
 }
 

--- a/server/routes/messages.ts
+++ b/server/routes/messages.ts
@@ -78,7 +78,7 @@ export function registerMessageRoutes(app: Express, { authenticateUser }: RouteC
 
   // 🔍 [DEBUG] Log all registered routes for verification
   console.log('🔍 [DEBUG] All registered routes:');
-  (app as any)._router.stack.forEach((middleware, index: number) => {
+  (app as any)._router.stack.forEach((middleware: { route?: { path: string } }, index: number) => {
     if (middleware.route) {
       console.log(`Route ${index}: ${middleware.route.path}`);
     }

--- a/server/routes/notifications.ts
+++ b/server/routes/notifications.ts
@@ -9,7 +9,7 @@ const createNotificationSchema = z.object({
   title: z.string().min(1).max(255),
   message: z.string().optional(),
   type: z.enum(["task_assigned", "task_updated", "general"]).default("general"),
-  taskId: z.number().optional(),
+  taskId: z.string().optional(),
 });
 
 export function registerNotificationRoutes(app: Express, { authenticateUser, requireRole }: RouteContext) {

--- a/server/utils/csvHelper.ts
+++ b/server/utils/csvHelper.ts
@@ -371,7 +371,7 @@ export async function parseCsvToScheduleItems(
 // Функция валидации элементов расписания
 export async function validateScheduleItems(
   scheduleItems: Partial<InsertScheduleItem>[],
-  validateSubject: (subjectId: number) => Promise<boolean>
+  validateSubject: (subjectId: string) => Promise<boolean>
 ): Promise<{ validItems: InsertScheduleItem[], errors: ScheduleImportError[] }> {
   const validItems: InsertScheduleItem[] = [];
   const errors: ScheduleImportError[] = [];

--- a/server/utils/googleSheetsHelper.ts
+++ b/server/utils/googleSheetsHelper.ts
@@ -157,11 +157,11 @@ export function parseSheetDataToScheduleItems(
       // Для реального приложения нужно добавить поиск по базе данных
       // Используем ту же логику, что и в csvHelper.ts для консистентности
       const subjectName = rowData['Предмет'];
-      const getSubjectId = (name: string): number => {
+      const getSubjectId = (name: string): string => {
         const hash = name.split('').reduce((acc, char) => acc + char.charCodeAt(0), 0);
-        return (hash % 100) + 1; // От 1 до 100, чтобы избежать ID = 0
+        return String((hash % 100) + 1); // От 1 до 100, чтобы избежать ID = 0
       };
-      
+
       item.subjectId = getSubjectId(subjectName);
 
       scheduleItems.push(item);


### PR DESCRIPTION
## Summary
- remove `user_metadata` usage in auth
- allow UUID in curriculum plan routes
- return string default teacher id
- type middleware when logging routes
- accept string IDs in notification routes
- validate schedule items using string IDs
- use string subject IDs from Google Sheets
- update notification id handling in DB storage
- grade assignments using string submission IDs

## Testing
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_685ba164707883209efe67530a5e72c2