### PR TITLE
Fix executorId parse issue

### DIFF
--- a/client/src/pages/tasks/CreateTaskDialog.tsx
+++ b/client/src/pages/tasks/CreateTaskDialog.tsx
@@ -87,7 +87,7 @@ export default function CreateTaskDialog({ open, onOpenChange, form, loading, us
                 <FormItem>
                   <FormLabel>{t('task.assignee')}</FormLabel>
                   <Select
-                    onValueChange={value => field.onChange(parseInt(value))}
+                    onValueChange={value => field.onChange(value)}
                     defaultValue={field.value ? String(field.value) : undefined}
                   >
                     <FormControl>

--- a/client/src/pages/tasks/EditTaskDialog.tsx
+++ b/client/src/pages/tasks/EditTaskDialog.tsx
@@ -69,7 +69,7 @@ export default function EditTaskDialog({ open, onOpenChange, form, onSubmit, loa
                 <FormItem>
                   <FormLabel>{t('task.assignee')}</FormLabel>
                   <Select
-                    onValueChange={value => field.onChange(parseInt(value))}
+                    onValueChange={value => field.onChange(value)}
                     defaultValue={field.value ? String(field.value) : undefined}
                   >
                     <FormControl>


### PR DESCRIPTION
## Summary
- ensure UUID string values pass through without parsing to number

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_685ba9f2bb6c8320b6db22cc9bc534da