### PR TITLE
Add debug logs around assignment route registration

### DIFF
--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -213,7 +213,17 @@ export async function registerRoutes(app: Express): Promise<Server> {
   registerTaskRoutes(app, ctx);
 
   // Основные разделы
-  registerAssignmentRoutes(app, ctx);
+  console.log('🔍 [DEBUG] About to register assignment routes...');
+  try {
+    registerAssignmentRoutes(app, ctx);
+    console.log('✅ [DEBUG] Assignment routes registered successfully');
+  } catch (error) {
+    console.error('❌ [CRITICAL] Assignment routes registration FAILED:', error);
+    // error may not have stack if it's not Error; guard
+    if (error && (error as any).stack) {
+      console.error('❌ [STACK]', (error as any).stack);
+    }
+  }
   registerNotificationRoutes(app, ctx);
 
   // Временное отключение второстепенных модулей


### PR DESCRIPTION
## Summary
- add debug and error logging when registering assignment routes

## Testing
- `npm run check`
- `npx tsx --test server/routes/__tests__/messages.read.test.js`
- `npx tsx --test server/routes/curriculum-weeks.test.js` *(fails: esbuild binary for wrong platform)*

------
https://chatgpt.com/codex/tasks/task_e_685bb8a392d08320912fc8fcebcec130