### PR TITLE
Add missing i18n strings

### DIFF
--- a/client/src/i18n/locales/en.json
+++ b/client/src/i18n/locales/en.json
@@ -34,9 +34,10 @@
     "total": "Total",
     "added": "Added:",
     "taskManager": "Task Manager",
+    "loading": "Loading...",
     "status": {
-      "loading": "Loading...",
       "success": "Success",
+      "loading": "Loading...",
       "error": "Error",
       "pending": "Pending",
       "completed": "Completed",
@@ -283,7 +284,9 @@
     "addSuccess": "Schedule item added successfully",
     "addError": "Error adding schedule item: {{message}}",
     "updateSuccess": "Schedule item updated successfully",
-    "updateError": "Error updating schedule item: {{message}}"
+    "updateError": "Error updating schedule item: {{message}}",
+    "noClassesToday": "You have no classes today",
+    "viewFull": "View full schedule"
   },
   "assignments": {
     "title": "Assignments",
@@ -302,6 +305,7 @@
     "assignedBy": "Assigned by",
     "maxScore": "Maximum score",
     "status": "Status",
+    "noActiveAssignments": "You have no active assignments",
     "attachments": "Attachments",
     "submissions": "Submissions",
     "actions": "Actions",
@@ -363,6 +367,7 @@
   },
   "requests": {
     "title": "Requests",
+    "pending": "Active requests",
     "list": "Request list",
     "add": "Add request",
     "edit": "Edit request",

--- a/client/src/i18n/locales/ru.json
+++ b/client/src/i18n/locales/ru.json
@@ -55,6 +55,7 @@
     "total": "Всего",
     "added": "Добавлен:",
     "taskManager": "Менеджер задач",
+    "loading": "Загрузка...",
     "status": {
       "loading": "Загрузка...",
       "success": "Успешно",
@@ -303,6 +304,7 @@
       "needGrading": "Заданий требуют оценки",
       "studentActivity": "Активность студентов",
       "studentHelp": "Студентам требуется помощь",
+        "allActive": "Все студенты активны",
       "newRequests": "Новых запросов от студентов",
       "assignNewTask": "Назначить задание",
       "totalStudents": "Всего студентов"
@@ -395,7 +397,9 @@
     "addSuccess": "Занятие успешно добавлено",
     "addError": "Ошибка добавления занятия: {{message}}",
     "updateSuccess": "Занятие успешно обновлено",
-    "updateError": "Ошибка обновления занятия: {{message}}"
+    "updateError": "Ошибка обновления занятия: {{message}}",
+    "noClassesToday": "Сегодня у вас нет занятий",
+    "viewFull": "Просмотреть полное расписание"
   },
   "settings": {
     "language": "Язык",
@@ -416,7 +420,9 @@
     "appearance": "Внешний вид"
   },
   "assignments": {
-    "title": "Задания"
+    "title": "Задания",
+    "status": "Статус",
+    "noActiveAssignments": "У вас нет активных заданий"
   },
   "grades": {
     "title": "Оценки"
@@ -432,6 +438,7 @@
 
   "requests": {
     "title": "Запросы",
+    "pending": "Активные заявки",
     "noRequests": "Заявки отсутствуют",
     "addSuccess": "Запрос успешно создан"
   },


### PR DESCRIPTION
## Summary
- add new Russian translations for dashboard, requests, assignments and schedule
- mirror the new keys in English locale files

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_685bc518406883208173b3c41305315f