### PR TITLE
Add i18n keys

### DIFF
--- a/client/src/i18n/locales/en.json
+++ b/client/src/i18n/locales/en.json
@@ -183,7 +183,10 @@
     "messages": "Messages",
     "settings": "Settings",
     "help": "Help",
-    "logout": "Logout"
+    "logout": "Logout",
+    "teacher": {
+      "studentInactivity": "Student Inactivity"
+    }
   },
   "users": {
     "title": "Users",
@@ -291,7 +294,7 @@
   "assignments": {
     "title": "Assignments",
     "list": "Assignment list",
-    "add": "Add assignment",
+    "add": "Add Assignment",
     "edit": "Edit assignment",
     "delete": "Delete assignment",
     "details": "Assignment details",
@@ -335,7 +338,8 @@
     "addSuccess": "Assignment added successfully",
     "addError": "Error adding assignment: {{message}}",
     "updateSuccess": "Assignment updated successfully",
-    "updateError": "Error updating assignment: {{message}}"
+    "updateError": "Error updating assignment: {{message}}",
+    "viewAll": "View All"
   },
   "grades": {
     "title": "Grades",
@@ -368,6 +372,7 @@
   "requests": {
     "title": "Requests",
     "pending": "Active requests",
+    "noPending": "No Pending Requests",
     "list": "Request list",
     "add": "Add request",
     "edit": "Edit request",

--- a/client/src/i18n/locales/ru.json
+++ b/client/src/i18n/locales/ru.json
@@ -303,6 +303,7 @@
       "pendingSubmissions": "Ожидающие проверки работы",
       "needGrading": "Заданий требуют оценки",
       "studentActivity": "Активность студентов",
+      "studentInactivity": "Неактивность студентов",
       "studentHelp": "Студентам требуется помощь",
         "allActive": "Все студенты активны",
       "newRequests": "Новых запросов от студентов",
@@ -422,7 +423,9 @@
   "assignments": {
     "title": "Задания",
     "status": "Статус",
-    "noActiveAssignments": "У вас нет активных заданий"
+    "noActiveAssignments": "У вас нет активных заданий",
+    "add": "Добавить задание",
+    "viewAll": "Посмотреть все"
   },
   "grades": {
     "title": "Оценки"
@@ -439,6 +442,7 @@
   "requests": {
     "title": "Запросы",
     "pending": "Активные заявки",
+    "noPending": "Нет ожидающих запросов",
     "noRequests": "Заявки отсутствуют",
     "addSuccess": "Запрос успешно создан"
   },


### PR DESCRIPTION
## Summary
- add missing translation keys in `en.json` and `ru.json`

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_685bcac45f7c83209c1920b09ec9747b