### PR TITLE
Implement centralized task permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,3 +89,9 @@ npm run dev:client
 The server will automatically use `SupabaseStorage` for all data access.
 
 Note: The API is available at http://localhost:3001.
+
+## Student capabilities
+
+Students can create tasks for themselves, update the details or status of tasks
+they own, and view tasks assigned to them. They cannot delete tasks or view
+other users' information unless explicitly shared with them.

--- a/server/routes/tasks.ts
+++ b/server/routes/tasks.ts
@@ -7,11 +7,12 @@ import { logger } from "../utils/logger";
 import { requireRole } from "../middleware/requireRole";
 import { NotificationService } from "../services/NotificationService";
 import { getTaskStatusLabel } from '@shared/utils';
+import { taskPermissions } from '../types/auth';
 
 export function registerTaskRoutes(app: Express, { authenticateUser }: RouteContext) {
 // Tasks Routes
 // GET /api/tasks - list all tasks (admin only)
-app.get('/api/tasks', authenticateUser, requireRole(['admin']), async (_req, res) => {
+app.get('/api/tasks', authenticateUser, requireRole(taskPermissions.view), async (_req, res) => {
   try {
     const tasks = await getStorage().getTasks();
     res.json(tasks);
@@ -155,7 +156,7 @@ app.get('/api/tasks/due-soon/:days', authenticateUser, async (req, res) => {
 
 // POST /api/tasks - create a new task
 // Allowed roles: admin, teacher, student, director
-app.post('/api/tasks', authenticateUser, requireRole(['admin', 'teacher', 'student', 'director']), async (req, res) => {
+app.post('/api/tasks', authenticateUser, requireRole(taskPermissions.create), async (req, res) => {
   try {
     // Модифицируем схему вставки задачи для преобразования строки даты в объект Date
     const modifiedTaskSchema = insertTaskSchema.extend({
@@ -218,7 +219,7 @@ app.post('/api/tasks', authenticateUser, requireRole(['admin', 'teacher', 'stude
 
 // Endpoint для удаления задачи
 // DELETE /api/tasks/:id - delete a task (admin only)
-app.delete('/api/tasks/:id', authenticateUser, requireRole(['admin']), async (req, res) => {
+app.delete('/api/tasks/:id', authenticateUser, requireRole(taskPermissions.delete), async (req, res) => {
   try {
     const taskId = req.params.id;
     const task = await getStorage().getTask(taskId);
@@ -264,7 +265,7 @@ app.delete('/api/tasks/:id', authenticateUser, requireRole(['admin']), async (re
 
 // PUT /api/tasks/:id - update a task
 // Allowed roles: admin, teacher, student, director
-app.put('/api/tasks/:id', authenticateUser, requireRole(['admin', 'teacher', 'student', 'director']), async (req, res) => {
+app.put('/api/tasks/:id', authenticateUser, requireRole(taskPermissions.update), async (req, res) => {
   try {
     const taskId = req.params.id;
     const task = await getStorage().getTask(taskId);
@@ -469,7 +470,7 @@ app.get('/api/users/:id/notifications', authenticateUser, async (req, res) => {
 // PATCH /api/tasks/:id/status - обновить статус задачи
 // PATCH /api/tasks/:id/status - update task status
 // Allowed roles: admin, teacher, student, director
-app.patch('/api/tasks/:id/status', authenticateUser, requireRole(['admin', 'teacher', 'student', 'director']), async (req, res) => {
+app.patch('/api/tasks/:id/status', authenticateUser, requireRole(taskPermissions.update), async (req, res) => {
   try {
     const taskId = req.params.id;
     const { status } = req.body;

--- a/server/routes/users.ts
+++ b/server/routes/users.ts
@@ -7,7 +7,6 @@ import { logger } from "../utils/logger";
 import { supabase } from "../supabaseClient";
 import { db } from "../db/index";
 import * as schema from "@shared/schema";
-import { getDbUserBySupabaseUser } from "../utils/userMapping";
 
 export function registerUserRoutes(app: Express, { authenticateUser, requireRole }: RouteContext) {
   // User Routes
@@ -19,8 +18,7 @@ export function registerUserRoutes(app: Express, { authenticateUser, requireRole
     }
 
     try {
-      const { role } = await getDbUserBySupabaseUser(req.user);
-      if (role !== 'admin') {
+      if (req.user.role !== 'admin') {
         return res.status(403).json({ message: 'Forbidden - Admin access required' });
       }
 

--- a/server/types/auth.ts
+++ b/server/types/auth.ts
@@ -12,3 +12,10 @@ import type { Request } from 'express';
 export interface AuthenticatedRequest extends Request {
   user?: AuthenticatedUser;
 }
+
+export const taskPermissions = {
+  create: ['admin', 'teacher', 'student', 'director'] as UserRole[],
+  update: ['admin', 'teacher', 'student', 'director'] as UserRole[],
+  delete: ['admin'] as UserRole[],
+  view: ['admin'] as UserRole[],
+};


### PR DESCRIPTION
## Summary
- refactor users route to rely on `req.user` instead of fetching user data again
- add `taskPermissions` map in `server/types/auth.ts`
- use permission map inside task routes
- document what students can do in README

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_685bf9c9f9b083208c0abab5d0694b9d