### PR TITLE
Fix task creation permissions

### DIFF
--- a/server/types/auth.ts
+++ b/server/types/auth.ts
@@ -14,7 +14,7 @@ export interface AuthenticatedRequest extends Request {
 }
 
 export const taskPermissions = {
-  create: ['admin', 'teacher', 'student', 'director'] as UserRole[],
+  create: ['admin', 'director'] as UserRole[],
   update: ['admin', 'teacher', 'student', 'director'] as UserRole[],
   delete: ['admin'] as UserRole[],
   view: ['admin'] as UserRole[],


### PR DESCRIPTION
## Summary
- restrict task creation to admin and director roles only

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_685c02836c388320ad4baed0e1aae777