### PR TITLE
Add filtered tasks endpoint for current user

### DIFF
--- a/server/db/storage.ts
+++ b/server/db/storage.ts
@@ -860,6 +860,10 @@ export class SupabaseStorage {
     return this.tasksRepo.getTasksByExecutor(executorId);
   }
 
+  async getTasksByUser(userId: string): Promise<(Task & { client?: UserSummary; executor?: UserSummary })[]> {
+    return this.tasksRepo.getTasksByUser(userId);
+  }
+
   async getTasksByStatus(status: string): Promise<Task[]> {
     return this.tasksRepo.getTasksByStatus(status);
   }

--- a/server/routes/tasks.ts
+++ b/server/routes/tasks.ts
@@ -28,6 +28,23 @@ app.get('/api/tasks', authenticateUser, requireRole(taskPermissions.view), async
   }
 });
 
+// GET /api/tasks/my - get user's tasks (filtered)
+app.get('/api/tasks/my', authenticateUser, requireRole(['teacher', 'student', 'admin', 'director']), async (req, res) => {
+  try {
+    const userId = req.user!.id;
+    const tasks = await getStorage().getTasksByUser(userId);
+    res.json(tasks);
+  } catch (error) {
+    logger.error('Error fetching user tasks:', error);
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    res.status(500).json({
+      message: 'Error fetching user tasks',
+      details: errorMessage,
+      timestamp: new Date().toISOString(),
+    });
+  }
+});
+
 app.get('/api/tasks/client/:clientId', authenticateUser, async (req, res) => {
   try {
     const clientId = req.params.clientId;

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -194,6 +194,7 @@ export interface IStorage {
   getTaskById(id: string): Promise<Task | null>; // Добавляем другой формат возврата для совместимости
   getTasksByClient(clientId: string): Promise<Task[]>; // UUID
   getTasksByExecutor(executorId: string): Promise<Task[]>; // UUID
+  getTasksByUser(userId: string): Promise<Task[]>; // UUID
   getTasksByStatus(status: string): Promise<Task[]>;
   getTasksDueSoon(days: number): Promise<Task[]>;
   createTask(taskData: InsertTask): Promise<Task>;
@@ -1381,6 +1382,13 @@ export class MemStorage implements IStorage {
   async getTasksByExecutor(executorId: string): Promise<Task[]> {
     return Array.from(this.tasks.values())
       .filter(task => task.executorId === executorId);
+  }
+
+  async getTasksByUser(userId: string): Promise<Task[]> {
+    const clientTasks = await this.getTasksByClient(userId);
+    const executorTasks = await this.getTasksByExecutor(userId);
+    const all = [...clientTasks, ...executorTasks];
+    return all.filter((task, index, self) => self.findIndex(t => t.id === task.id) === index);
   }
   
   async getTasksByStatus(status: string): Promise<Task[]> {


### PR DESCRIPTION
## Summary
- expose `/api/tasks/my` to fetch tasks relevant to the logged‑in user
- extend storage interface with `getTasksByUser`
- implement user task filtering in memory and Supabase storage
- add repository logic for querying tasks for a specific user

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_685cf13d7a48832080db7761e4dd39ff