### PR TITLE
Implement role-based task listing

### DIFF
--- a/client/src/components/tasks/TaskDetailsModal.tsx
+++ b/client/src/components/tasks/TaskDetailsModal.tsx
@@ -47,6 +47,10 @@ const TaskDetailsModal: React.FC<TaskDetailsModalProps> = ({
   const { toast } = useToast();
   const queryClient = useQueryClient();
   const { user } = useAuth();
+  const tasksEndpoint =
+    user?.role === 'admin' || user?.role === 'director'
+      ? '/api/tasks'
+      : '/api/tasks/my';
   const [isUpdating, setIsUpdating] = useState(false);
   
 
@@ -87,7 +91,7 @@ const TaskDetailsModal: React.FC<TaskDetailsModalProps> = ({
 
       // Инвалидация кэша задач
       queryClient.invalidateQueries({ queryKey: ['/api/users', userId, 'tasks'] });
-      queryClient.invalidateQueries({ queryKey: ['/api/tasks'] });
+      queryClient.invalidateQueries({ queryKey: [tasksEndpoint] });
       
       // Вызов пользовательского обработчика
       if (onStatusChange) {

--- a/client/src/pages/tasks/useTasks.ts
+++ b/client/src/pages/tasks/useTasks.ts
@@ -48,8 +48,13 @@ export function useTasks() {
     staleTime: 1000 * 60 * 5,
   });
 
+  const tasksEndpoint =
+    user?.role === 'admin' || user?.role === 'director'
+      ? '/api/tasks'
+      : '/api/tasks/my';
+
   const { data: tasks, isLoading: tasksLoading } = useQuery<Task[]>({
-    queryKey: ['/api/tasks'],
+    queryKey: [tasksEndpoint],
     enabled: !!user,
   });
 
@@ -83,7 +88,7 @@ export function useTasks() {
       return result;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['/api/tasks'] });
+      queryClient.invalidateQueries({ queryKey: [tasksEndpoint] });
       toast({
         title: t('task.created_success'),
         description: t('task.created_description'),
@@ -105,7 +110,7 @@ export function useTasks() {
       return result;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['/api/tasks'] });
+      queryClient.invalidateQueries({ queryKey: [tasksEndpoint] });
       // also refresh notifications when status changes
       queryClient.invalidateQueries({ queryKey: ['/api/notifications'] });
       setTimeout(() => {
@@ -132,7 +137,7 @@ export function useTasks() {
       return result;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['/api/tasks'] });
+      queryClient.invalidateQueries({ queryKey: [tasksEndpoint] });
       toast({
         title: t('task.deleted_success'),
         description: t('task.deleted_description'),
@@ -163,7 +168,7 @@ export function useTasks() {
       return result;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['/api/tasks'] });
+      queryClient.invalidateQueries({ queryKey: [tasksEndpoint] });
       // invalidate notifications so new updates appear instantly
       queryClient.invalidateQueries({ queryKey: ['/api/notifications'] });
       // perform a delayed refetch to ensure UI is up to date


### PR DESCRIPTION
## Summary
- fetch tasks from `/api/tasks` for admins/directors and from `/api/tasks/my` for teachers/students
- invalidate the correct task query depending on the role

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_685cf73e65dc832086c9e352c2f35a45