### PR TITLE
Fix status update endpoint

### DIFF
--- a/client/src/pages/tasks/useTasks.ts
+++ b/client/src/pages/tasks/useTasks.ts
@@ -106,7 +106,7 @@ export function useTasks() {
 
   const updateTaskStatusMutation = useMutation({
     mutationFn: async ({ id, status }: { id: number; status: string }) => {
-      const result = await apiRequest(`/api/tasks/${id}`, 'PUT', { status });
+      const result = await apiRequest(`/api/tasks/${id}/status`, 'PATCH', { status });
       return result;
     },
     onSuccess: () => {


### PR DESCRIPTION
## Summary
- update task status dropdown to call PATCH `/api/tasks/:id/status`

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_685cfd222a7c83208e9c8fc9416715b6