### PR TITLE
Fix task status update to use getTask

### DIFF
--- a/server/routes/tasks.ts
+++ b/server/routes/tasks.ts
@@ -497,7 +497,7 @@ app.patch('/api/tasks/:id/status', authenticateUser, async (req, res) => {
     }
     
     // Получаем текущую задачу
-    const task = await getStorage().getTaskById(taskId);
+    const task = await getStorage().getTask(taskId);
     
     if (!task) {
       return res.status(404).json({ message: "Task not found" });


### PR DESCRIPTION
## Summary
- fix the PATCH `/api/tasks/:id/status` route to use `getTask`

## Testing
- `node --test server/routes/__tests__/tasks.access.test.js server/routes/__tests__/messages.read.test.js`


------
https://chatgpt.com/codex/tasks/task_e_685d00e6b13883208f3a2b398ae1af53