### PR TITLE
Fix task description visibility on mobile

### DIFF
--- a/client/src/components/tasks/TaskCard.tsx
+++ b/client/src/components/tasks/TaskCard.tsx
@@ -54,7 +54,10 @@ const TaskCard = ({ task, onStatusChange, onEditClick, onDeleteClick, onViewDeta
         </div>
       </CardHeader>
       <CardContent className="flex-grow">
-        <p className="text-sm mb-3 line-clamp-4 hide-md" title={task.description || t('task.no_description')}>
+        <p
+          className="text-sm mb-3 line-clamp-4"
+          title={task.description || t('task.no_description')}
+        >
           {task.description || t('task.no_description')}
         </p>
         <div className="space-y-2 text-sm">


### PR DESCRIPTION
## Summary
- show the task description on mobile by removing the `hide-md` class

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_685d18eef6fc8320aca99da9619eaaeb