### PR TITLE
Fix layout of task card labels

### DIFF
--- a/client/src/components/tasks/TaskBadges.tsx
+++ b/client/src/components/tasks/TaskBadges.tsx
@@ -1,11 +1,13 @@
 import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
 import { useTranslation } from 'react-i18next';
 
 interface StatusBadgeProps {
   status: string;
+  className?: string;
 }
 
-export function StatusBadge({ status }: StatusBadgeProps) {
+export function StatusBadge({ status, className }: StatusBadgeProps) {
   const { t } = useTranslation();
   const map: Record<string, { label: string; className: string }> = {
     new: {
@@ -31,7 +33,7 @@ export function StatusBadge({ status }: StatusBadgeProps) {
   };
   const info = map[status];
   return (
-    <Badge variant="outline" className={info?.className}>
+    <Badge variant="outline" className={cn(info?.className, className)}>
       {info ? info.label : status}
     </Badge>
   );
@@ -39,9 +41,10 @@ export function StatusBadge({ status }: StatusBadgeProps) {
 
 interface PriorityBadgeProps {
   priority: string;
+  className?: string;
 }
 
-export function PriorityBadge({ priority }: PriorityBadgeProps) {
+export function PriorityBadge({ priority, className }: PriorityBadgeProps) {
   const { t } = useTranslation();
   const map: Record<string, { label: string; className: string }> = {
     high: {
@@ -62,7 +65,7 @@ export function PriorityBadge({ priority }: PriorityBadgeProps) {
   };
   const info = map[priority];
   return (
-    <Badge variant="outline" className={info?.className}>
+    <Badge variant="outline" className={cn(info?.className, className)}>
       {info ? info.label : priority}
     </Badge>
   );

--- a/client/src/components/tasks/TaskCard.tsx
+++ b/client/src/components/tasks/TaskCard.tsx
@@ -43,15 +43,19 @@ const TaskCard = ({ task, onStatusChange, onEditClick, onDeleteClick, onViewDeta
       onClick={handleCardClick}
     >
       <CardHeader className="pb-2 space-y-2">
-        <div className="flex justify-between items-start">
-          <CardTitle className="text-lg break-words" title={task.title}>
-            {task.title}
-          </CardTitle>
-          <div className="flex gap-1">
-            <PriorityBadge priority={task.priority} />
-            <StatusBadge status={task.status} />
-          </div>
+        <div className="flex gap-1 flex-wrap">
+          <PriorityBadge
+            priority={task.priority}
+            className="px-2 py-0.5 text-[10px]"
+          />
+          <StatusBadge
+            status={task.status}
+            className="px-2 py-0.5 text-[10px]"
+          />
         </div>
+        <CardTitle className="text-lg break-words" title={task.title}>
+          {task.title}
+        </CardTitle>
       </CardHeader>
       <CardContent className="flex-grow">
         <p


### PR DESCRIPTION
## Summary
- move status/priority labels above title
- add optional className prop to TaskBadge components
- reduce label sizes on task cards

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_685d1bdb5ac08320aa321be5b342c13d