### PR TITLE
Improve task page layout

### DIFF
--- a/client/src/pages/tasks/CreateTaskDialog.tsx
+++ b/client/src/pages/tasks/CreateTaskDialog.tsx
@@ -16,15 +16,28 @@ import { TaskFormData, type UserSummary } from './useTasks';
 import React from 'react';
 
 interface Props {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-  form: UseFormReturn<TaskFormData>;
-  loading: boolean;
-  users: UserSummary[] | undefined;
-  onSubmit?: (data: TaskFormData) => void;
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  form: UseFormReturn<TaskFormData>
+  loading: boolean
+  users: UserSummary[] | undefined
+  onSubmit?: (data: TaskFormData) => void
+  /**
+   * Optional className applied to the trigger button. Allows consumers to
+   * adjust size or other styles depending on the layout.
+   */
+  triggerClassName?: string
 }
 
-export default function CreateTaskDialog({ open, onOpenChange, form, loading, users, onSubmit }: Props) {
+export default function CreateTaskDialog({
+  open,
+  onOpenChange,
+  form,
+  loading,
+  users,
+  onSubmit,
+  triggerClassName,
+}: Props) {
   const { t } = useTranslation();
 
 
@@ -40,9 +53,10 @@ export default function CreateTaskDialog({ open, onOpenChange, form, loading, us
       <DialogTrigger asChild>
         <Button
           onClick={() => {
-            onOpenChange(true);
+            onOpenChange(true)
           }}
           type="button"
+          className={triggerClassName}
         >
           {t('task.create_new')}
         </Button>

--- a/client/src/pages/tasks/Tasks.tsx
+++ b/client/src/pages/tasks/Tasks.tsx
@@ -119,18 +119,6 @@ const TasksPage = () => {
 
   return (
     <div className="container py-8 px-8">
-      <div className="flex justify-end items-center mb-6">
-        {canCreateTask && (
-          <CreateTaskDialog
-            open={createDialogOpen}
-            onOpenChange={setCreateDialogOpen}
-            form={form}
-            loading={createTaskMutation.isPending}
-            users={users}
-            onSubmit={handleCreateTask}
-          />
-        )}
-      </div>
 
         {/* Диалог редактирования задачи */}
         <EditTaskDialog
@@ -160,9 +148,8 @@ const TasksPage = () => {
           onDelete={handleDeleteClick}
         />
 
-      {/* Фильтры */}
-      <div className="mb-6">
-        {/* Mobile Dropdown */}
+      {/* Filters and create button */}
+      <div className="mb-6 flex flex-wrap items-center justify-between gap-4">
         <div className="md:hidden">
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
@@ -248,7 +235,19 @@ const TasksPage = () => {
             <PauseCircle className="h-4 w-4" />
             {t('task.status.on_hold')}
           </Button>
-        </div>
+      </div>
+
+        {canCreateTask && (
+          <CreateTaskDialog
+            open={createDialogOpen}
+            onOpenChange={setCreateDialogOpen}
+            form={form}
+            loading={createTaskMutation.isPending}
+            users={users}
+            onSubmit={handleCreateTask}
+            triggerClassName="h-9 px-3 text-sm md:h-11 md:px-4"
+          />
+        )}
       </div>
 
       {/* Содержимое */}


### PR DESCRIPTION
## Summary
- allow passing custom class name to `CreateTaskDialog` trigger
- place task filters and create button in one responsive row

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_685d25e467008320b913658aa3a137aa