### PR TITLE
Add settings page and route

### DIFF
--- a/client/src/pages/settings/Settings.tsx
+++ b/client/src/pages/settings/Settings.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardContent
+} from '@/components/ui/card';
+import { ThemeToggle } from '@/components/theme/theme-toggle';
+import { LanguageSwitcher } from '@/components/theme/language-switcher';
+
+export default function Settings() {
+  const { t } = useTranslation();
+
+  return (
+    <div className="container mx-auto py-6">
+      <h1 className="text-3xl font-bold mb-6">{t('settings.title')}</h1>
+
+      <Card className="max-w-md">
+        <CardHeader>
+          <CardTitle>{t('settings.appearance')}</CardTitle>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-4">
+          <div className="flex items-center justify-between">
+            <span>{t('settings.language')}</span>
+            <LanguageSwitcher />
+          </div>
+          <div className="flex items-center justify-between">
+            <span>{t('settings.theme')}</span>
+            <ThemeToggle />
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/client/src/routes.tsx
+++ b/client/src/routes.tsx
@@ -5,6 +5,7 @@ import AssignmentDetail from "@/pages/assignments/AssignmentDetail";
 import Schedule from "@/pages/schedule/Schedule";
 import Chat from "@/pages/chat/Chat";
 import TasksPage from "@/pages/tasks/Tasks";
+import SettingsPage from "@/pages/settings/Settings";
 import NotFound from "@/pages/not-found";
 import AuthPage from "@/pages/auth-page";
 import Users from "@/pages/users/Users";
@@ -60,6 +61,12 @@ const ProtectedTasks = () => (
   </MainLayout>
 );
 
+const ProtectedSettings = () => (
+  <MainLayout>
+    <SettingsPage />
+  </MainLayout>
+);
+
 const ProtectedUserDetail = () => (
   <MainLayout>
     <UserDetail />
@@ -78,6 +85,7 @@ export const routes: RouteDefinition[] = [
   { path: "/chat", component: ProtectedChat, protected: true },
   { path: "/chat/:id", component: ProtectedChat, protected: true },
   { path: "/tasks", component: ProtectedTasks, protected: true },
+  { path: "/settings", component: ProtectedSettings, protected: true },
   { component: NotFound },
 ];
 


### PR DESCRIPTION
## Summary
- implement a Settings page with language and theme controls
- register `/settings` route so navigation link works

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_685d40e46f148320886ccb665aa1e2b1