### PR TITLE
Fix notification type mismatch

### DIFF
--- a/client/src/components/notifications/NotificationBell.tsx
+++ b/client/src/components/notifications/NotificationBell.tsx
@@ -17,17 +17,8 @@ import { getTaskStatusLabel } from '@/lib/taskStatus';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { useToast } from '@/hooks/use-toast';
 
-// Определение типа для уведомлений
-export interface Notification {
-  id: number;
-  userId: string;
-  title: string;
-  content: string;
-  isRead: boolean;
-  createdAt: string;
-  relatedId?: number | null;
-  relatedType?: string | null;
-}
+import type { Notification } from '@shared/schema';
+
 
 export const NotificationBell = () => {
   const { t, i18n } = useTranslation();
@@ -55,7 +46,7 @@ export const NotificationBell = () => {
   const unreadCount = notifications.filter(notification => !notification.isRead).length;
 
   // Обработчик для отметки уведомления как прочитанное
-  const markAsRead = async (id: number) => {
+  const markAsRead = async (id: string) => {
     try {
       await apiRequest(`/api/notifications/${id}/read`, 'PATCH');
       queryClient.invalidateQueries({ queryKey: ['/api/notifications'] });

--- a/client/src/hooks/useNotifications.ts
+++ b/client/src/hooks/useNotifications.ts
@@ -2,7 +2,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useEffect } from 'react';
 import { apiRequest } from '@/lib/queryClient';
 import { supabase } from '@/lib/supabase';
-import type { Notification } from '@/types/notifications';
+import type { Notification } from '@shared/schema';
 
 export function useNotifications() {
   const queryClient = useQueryClient();
@@ -27,7 +27,7 @@ export function useNotifications() {
 
   // Mark a single notification as read
   const markAsReadMutation = useMutation({
-    mutationFn: async (notificationId: number) => {
+    mutationFn: async (notificationId: string) => {
       await apiRequest(`/api/notifications/${notificationId}/read`, 'PATCH');
     },
     onSuccess: () => {
@@ -47,7 +47,7 @@ export function useNotifications() {
 
   // Delete a notification
   const deleteNotificationMutation = useMutation({
-    mutationFn: async (notificationId: number) => {
+    mutationFn: async (notificationId: string) => {
       await apiRequest(`/api/notifications/${notificationId}`, 'DELETE');
     },
     onSuccess: () => {

--- a/client/src/hooks/useStudentDetail.ts
+++ b/client/src/hooks/useStudentDetail.ts
@@ -1,7 +1,7 @@
 import React, { useCallback, useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { apiRequest } from '@/lib/queryClient';
-import { Notification } from '@/types/notifications';
+import { Notification } from '@shared/schema';
 import StudentCard, { Student, UpcomingLesson } from '@/components/students/StudentCard';
 import { Task } from '@/components/students/StudentTaskItem';
 

--- a/client/src/types/notifications.ts
+++ b/client/src/types/notifications.ts
@@ -1,10 +1,7 @@
-export interface Notification {
-  id: number;
-  userId: string;
-  title: string;
-  content: string;
-  isRead: boolean;
-  createdAt: string;
-  relatedId?: number | null;
-  relatedType?: string | null;
-}
+// Re-export the Notification type from the shared schema to keep
+// the frontend in sync with the backend definitions. The backend
+// uses UUID strings for identifiers, so the type reflects that.
+
+import type { Notification as SharedNotification } from '@shared/schema';
+
+export type Notification = SharedNotification;


### PR DESCRIPTION
## Summary
- sync notification types with backend UUIDs
- update NotificationBell and hooks to use shared Notification type

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_685d6c789cfc8320887a1675a987718f