### PR TITLE
Add user preferences API

### DIFF
--- a/server/db/storage.ts
+++ b/server/db/storage.ts
@@ -690,6 +690,39 @@ export class SupabaseStorage {
     return notificationQueries.markAllNotificationsAsRead(userId);
   }
 
+  // User Preferences
+  async getUserPreferences(userId: string): Promise<schema.UserPreferences | undefined> {
+    const prefs = await db.select().from(schema.userPreferences)
+      .where(eq(schema.userPreferences.userId, userId)).limit(1);
+    return prefs[0];
+  }
+
+  async createUserPreferences(userId: string, prefs: schema.InsertUserPreferences): Promise<schema.UserPreferences> {
+    const now = new Date();
+    const [record] = await db.insert(schema.userPreferences)
+      .values({
+        ...prefs,
+        userId,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .returning();
+    return record;
+  }
+
+  async updateUserPreferences(userId: string, prefs: Partial<schema.InsertUserPreferences>): Promise<schema.UserPreferences | undefined> {
+    if (Object.keys(prefs).length === 0) {
+      const existing = await this.getUserPreferences(userId);
+      return existing;
+    }
+    const now = new Date();
+    const [record] = await db.update(schema.userPreferences)
+      .set({ ...prefs, updatedAt: now })
+      .where(eq(schema.userPreferences.userId, userId))
+      .returning();
+    return record;
+  }
+
   // Imported Files
   async getImportedFiles(): Promise<ImportedFile[]> {
     return db.select().from(schema.importedFiles)

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -39,6 +39,7 @@ import { registerMessageRoutes } from "./messages";
 import { registerRequestRoutes } from "./requests";
 import { registerDocumentRoutes } from "./documents";
 import { registerNotificationRoutes } from "./notifications";
+import { registerUserPreferencesRoutes } from "./user-preferences";
 import { registerActivityLogRoutes } from "./activityLogs";
 import { registerCurriculumRoutes } from "./curriculum";
 import { verifySupabaseJwt } from "../middleware/verifySupabaseJwt";
@@ -225,6 +226,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   }
   registerNotificationRoutes(app, ctx);
+  registerUserPreferencesRoutes(app, ctx);
 
   // Временное отключение второстепенных модулей
   registerRequestRoutes(app, ctx);

--- a/server/routes/user-preferences.ts
+++ b/server/routes/user-preferences.ts
@@ -1,0 +1,65 @@
+import { Express } from 'express';
+import { getStorage } from '../storage';
+import type { RouteContext } from './index';
+import { insertUserPreferencesSchema } from '@shared/schema';
+import { updateUserPreferencesSchema } from '../types/user-preferences';
+import { z } from 'zod';
+
+export function registerUserPreferencesRoutes(app: Express, { authenticateUser }: RouteContext) {
+  app.get('/api/user-preferences', authenticateUser, async (req, res) => {
+    try {
+      const userId = req.user!.id;
+      let prefs = await getStorage().getUserPreferences(userId);
+      if (!prefs) {
+        prefs = {
+          userId,
+          theme: 'light',
+          language: 'en',
+          notificationsEnabled: true,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        };
+      }
+      res.json(prefs);
+    } catch {
+      res.status(500).json({ message: 'Failed to fetch preferences' });
+    }
+  });
+
+  app.post('/api/user-preferences', authenticateUser, async (req, res) => {
+    try {
+      const data = insertUserPreferencesSchema.parse(req.body);
+      const userId = req.user!.id;
+      const existing = await getStorage().getUserPreferences(userId);
+      if (existing) {
+        return res.status(409).json({ message: 'Preferences already exist' });
+      }
+      const prefs = await getStorage().createUserPreferences(userId, data);
+      res.status(201).json(prefs);
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        return res.status(400).json({ message: 'Validation error', errors: error.errors });
+      }
+      res.status(500).json({ message: 'Failed to create preferences' });
+    }
+  });
+
+  app.put('/api/user-preferences', authenticateUser, async (req, res) => {
+    try {
+      const data = updateUserPreferencesSchema.parse(req.body);
+      const userId = req.user!.id;
+      let prefs = await getStorage().getUserPreferences(userId);
+      if (!prefs) {
+        prefs = await getStorage().createUserPreferences(userId, data);
+        return res.status(201).json(prefs);
+      }
+      const updated = await getStorage().updateUserPreferences(userId, data);
+      res.json(updated);
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        return res.status(400).json({ message: 'Validation error', errors: error.errors });
+      }
+      res.status(500).json({ message: 'Failed to update preferences' });
+    }
+  });
+}

--- a/server/types/user-preferences.ts
+++ b/server/types/user-preferences.ts
@@ -1,0 +1,5 @@
+import { insertUserPreferencesSchema } from "@shared/schema";
+import { z } from "zod";
+
+export const updateUserPreferencesSchema = insertUserPreferencesSchema.partial();
+export type UpdateUserPreferences = z.infer<typeof updateUserPreferencesSchema>;

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -226,6 +226,16 @@ export const tasks = pgTable("tasks", {
   executorId: uuid("executor_id").references(() => users.id).notNull(), // кто исполняет задачу
 });
 
+// User Preferences
+export const userPreferences = pgTable("user_preferences", {
+  userId: uuid("user_id").primaryKey().references(() => users.id),
+  theme: varchar("theme", { length: 20 }).notNull().default('light'),
+  language: varchar("language", { length: 10 }).notNull().default('en'),
+  notificationsEnabled: boolean("notifications_enabled").notNull().default(true),
+  createdAt: timestamp("created_at").defaultNow(),
+  updatedAt: timestamp("updated_at").defaultNow(),
+});
+
 // Учебные планы (Curriculum Plans)
 export const curriculumPlans = pgTable("curriculum_plans", {
   id: uuid("id").primaryKey().defaultRandom(),
@@ -334,6 +344,12 @@ export const insertActivityLogSchema = createInsertSchema(activityLogs).omit({
   timestamp: true
 });
 
+export const insertUserPreferencesSchema = createInsertSchema(userPreferences).omit({
+  userId: true,
+  createdAt: true,
+  updatedAt: true,
+});
+
 export const insertTaskSchema = createInsertSchema(tasks)
   .omit({
     id: true,
@@ -406,6 +422,9 @@ export type InsertImportedFile = z.infer<typeof insertImportedFileSchema>;
 
 export type ActivityLog = typeof activityLogs.$inferSelect;
 export type InsertActivityLog = z.infer<typeof insertActivityLogSchema>;
+
+export type UserPreferences = typeof userPreferences.$inferSelect;
+export type InsertUserPreferences = z.infer<typeof insertUserPreferencesSchema>;
 
 export type Task = typeof tasks.$inferSelect;
 export type InsertTask = z.infer<typeof insertTaskSchema>;


### PR DESCRIPTION
## Summary
- support user preferences in schema and storage
- allow fetching and modifying preferences through new endpoints
- register routes for preferences

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_685d7cbd05208320a8477e19705db8f1