### PR TITLE
Fix router registration debug logging

### DIFF
--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -226,7 +226,20 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   }
   registerNotificationRoutes(app, ctx);
-  registerUserPreferencesRoutes(app, ctx);
+
+  console.log('🔍 [DEBUG] About to register user preferences routes...');
+  try {
+    if (typeof registerUserPreferencesRoutes !== 'function') {
+      throw new Error('registerUserPreferencesRoutes is not a function');
+    }
+    registerUserPreferencesRoutes(app, ctx);
+    console.log('✅ [DEBUG] User preferences routes registered successfully');
+  } catch (error) {
+    console.error('❌ [CRITICAL] User preferences routes registration FAILED:', error);
+    if (error && (error as any).stack) {
+      console.error('❌ [STACK]', (error as any).stack);
+    }
+  }
 
   // Временное отключение второстепенных модулей
   registerRequestRoutes(app, ctx);


### PR DESCRIPTION
## Summary
- add debug logging while registering user preferences routes

## Testing
- `npm run check`
- `npx tsx ./server/routes/__tests__/messages.read.test.js`
- `npx tsx ./server/routes/__tests__/tasks.access.test.js`


------
https://chatgpt.com/codex/tasks/task_e_685d98ed51848320bf8b3d7700624c5c