### PR TITLE
Add Settings page with switch controls

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -12,6 +12,7 @@ import Invoices from "@/pages/documents/Invoices";
 import Certificates from "@/pages/documents/Certificates";
 import ImportedFiles from "@/pages/admin/ImportedFiles";
 import TasksPage from "@/pages/tasks/Tasks";
+import SettingsPage from "@/pages/settings/Settings";
 import CurriculumPlans from "@/pages/curriculum/CurriculumPlans";
 import EditCurriculumPlan from "@/pages/curriculum/EditCurriculumPlan";
 import NotFound from "@/pages/not-found";
@@ -87,6 +88,12 @@ const ProtectedCertificates = () => (
 const ProtectedTasks = () => (
   <MainLayout>
     <TasksPage />
+  </MainLayout>
+);
+
+const ProtectedSettings = () => (
+  <MainLayout>
+    <SettingsPage />
   </MainLayout>
 );
 
@@ -177,7 +184,10 @@ function App() {
       
       {/* Tasks route */}
       <ProtectedRoute path="/tasks" component={ProtectedTasks} />
-      
+
+      {/* Settings route */}
+      <ProtectedRoute path="/settings" component={ProtectedSettings} />
+
       {/* Admin routes с проверкой на роль admin */}
       <ProtectedRoute path="/admin/imported-files" component={ProtectedImportedFiles} adminOnly={true} />
       <ProtectedRoute path="/curriculum-plans" component={ProtectedCurriculumPlans} adminOnly={true} />

--- a/client/src/i18n/locales/ru.json
+++ b/client/src/i18n/locales/ru.json
@@ -411,7 +411,10 @@
     "lightTheme": "Светлая тема",
     "darkTheme": "Тёмная тема",
     "systemTheme": "Системная тема",
-    "appearance": "Внешний вид"
+    "appearance": "Внешний вид",
+    "notificationSettings": "Настройки уведомлений",
+    "emailNotifications": "Email уведомления",
+    "browserNotifications": "Уведомления в браузере"
   },
   "assignments": {
     "title": "Задания"

--- a/client/src/pages/settings/Settings.tsx
+++ b/client/src/pages/settings/Settings.tsx
@@ -1,0 +1,40 @@
+import React, { useState } from "react";
+import { useTranslation } from 'react-i18next';
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Switch } from "@/components/ui/switch";
+import { Label } from "@/components/ui/label";
+
+export default function Settings() {
+  const { t } = useTranslation();
+  const [emailNotifications, setEmailNotifications] = useState(false);
+  const [browserNotifications, setBrowserNotifications] = useState(false);
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">{t('settings.title')}</h1>
+      <Card className="max-w-md">
+        <CardHeader>
+          <CardTitle>{t('settings.notificationSettings')}</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex items-center justify-between">
+            <Label htmlFor="email">{t('settings.emailNotifications')}</Label>
+            <Switch
+              id="email"
+              checked={emailNotifications}
+              onCheckedChange={setEmailNotifications}
+            />
+          </div>
+          <div className="flex items-center justify-between">
+            <Label htmlFor="browser">{t('settings.browserNotifications')}</Label>
+            <Switch
+              id="browser"
+              checked={browserNotifications}
+              onCheckedChange={setBrowserNotifications}
+            />
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create a basic `Settings` page using Radix Switch component
- expose `/settings` route in the main app
- extend Russian locale with notification strings

## Testing
- `npm run check` *(fails: several existing TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_685d9d755264832091059b5b25d9faee