### PR TITLE
Add test:api script and platform note

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ Follow the steps below to configure the connection and run the app locally.
 ## 1. Install dependencies
 
 Run `npm install` to install all server and client packages.
+When switching between macOS and Linux you must reinstall dependencies so that
+the platform specific **esbuild** binary matches your system. Remove the
+`node_modules` folder and run `npm ci` again whenever you move the project
+between different operating systems.
 
 ## 2. Create a Supabase project
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc -p tsconfig.check.json",
     "db:push": "drizzle-kit push",
-    "db:seed": "tsx server/db/seed.ts"
+    "db:seed": "tsx server/db/seed.ts",
+    "test:api": "tsx server/routes/curriculum-weeks.test.js && tsx server/routes/user-preferences.api.test.js"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",


### PR DESCRIPTION
## Summary
- document reinstalling dependencies when switching between macOS and Linux to avoid esbuild issues
- add `test:api` npm script

## Testing
- `npm run test:api` *(fails: esbuild platform mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_685dac39361c8320beaaa4fd96f6eb16