### PR TITLE
Redesign settings page

### DIFF
--- a/client/src/i18n/locales/en.json
+++ b/client/src/i18n/locales/en.json
@@ -561,6 +561,8 @@
   },
   "settings": {
     "title": "Settings",
+    "myProfile": "My Profile",
+    "languageAndTheme": "Language & Theme",
     "general": "General",
     "appearance": "Appearance",
     "profile": "Profile",

--- a/client/src/i18n/locales/ru.json
+++ b/client/src/i18n/locales/ru.json
@@ -404,6 +404,8 @@
     "viewFull": "Просмотреть полное расписание"
   },
   "settings": {
+    "myProfile": "Мой профиль",
+    "languageAndTheme": "Язык и тема",
     "language": "Язык",
     "languages": {
       "ru": "Русский",

--- a/client/src/pages/settings/Settings.tsx
+++ b/client/src/pages/settings/Settings.tsx
@@ -7,6 +7,14 @@ import {
   CardTitle,
   CardContent
 } from '@/components/ui/card';
+import {
+  Accordion,
+  AccordionItem,
+  AccordionTrigger,
+  AccordionContent
+} from '@/components/ui/accordion';
+import { LanguageSwitcher } from '@/components/theme/language-switcher';
+import { ThemeToggle } from '@/components/theme/theme-toggle';
 import { Switch } from '@/components/ui/switch';
 import EditUserProfileModal from '@/components/users/EditUserProfileModal';
 import { useAuth } from '@/hooks/use-auth';
@@ -26,45 +34,105 @@ export default function Settings() {
     <div className="container mx-auto py-6">
       <h1 className="text-3xl font-bold mb-6">{t('settings.title')}</h1>
 
-      <Card className="max-w-md mb-4">
-        <CardHeader>
-          <CardTitle>{t('settings.notifications')}</CardTitle>
-        </CardHeader>
-        <CardContent className="flex flex-col gap-4">
-          <div className="flex items-center justify-between">
-            <span>{t('settings.emailNotifications')}</span>
-            <Switch
-              checked={preferences?.emailNotifications}
-              onCheckedChange={handleToggle('emailNotifications')}
-            />
-          </div>
-          <div className="flex items-center justify-between">
-            <span>{t('settings.browserNotifications')}</span>
-            <Switch
-              checked={preferences?.browserNotifications}
-              onCheckedChange={handleToggle('browserNotifications')}
-            />
-          </div>
-          <div className="flex items-center justify-between">
-            <span>{t('settings.soundNotifications')}</span>
-            <Switch
-              checked={preferences?.soundNotifications}
-              onCheckedChange={handleToggle('soundNotifications')}
-            />
-          </div>
-        </CardContent>
-      </Card>
+      <Accordion
+        type="multiple"
+        defaultValue={["profile"]}
+        className="space-y-4 max-w-md"
+      >
+        <AccordionItem value="profile" className="border-none">
+          <Card>
+            <CardHeader>
+              <AccordionTrigger className="w-full text-left">
+                <CardTitle>{t('settings.myProfile')}</CardTitle>
+              </AccordionTrigger>
+            </CardHeader>
+            <AccordionContent>
+              <CardContent className="space-y-2">
+                {user && (
+                  <>
+                    <div className="flex items-center justify-between">
+                      <span className="text-sm text-muted-foreground">
+                        {t('auth.profile.firstName', 'Name')}
+                      </span>
+                      <span className="font-medium">
+                        {user.firstName} {user.lastName}
+                      </span>
+                    </div>
+                    <div className="flex items-center justify-between">
+                      <span className="text-sm text-muted-foreground">
+                        {t('user.email', 'Email')}
+                      </span>
+                      <span className="font-medium">{user.email}</span>
+                    </div>
+                    <div className="flex items-center justify-between">
+                      <span className="text-sm text-muted-foreground">
+                        {t('auth.profile.role', 'Role')}
+                      </span>
+                      <span className="font-medium">
+                        {t(`roles.${user.role}`)}
+                      </span>
+                    </div>
+                    <Button size="sm" onClick={() => setEditOpen(true)}>
+                      {t('auth.profile.updateProfile')}
+                    </Button>
+                  </>
+                )}
+              </CardContent>
+            </AccordionContent>
+          </Card>
+        </AccordionItem>
 
-      <Card className="max-w-md">
-        <CardHeader>
-          <CardTitle>{t('settings.profile')}</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <Button onClick={() => setEditOpen(true)}>
-            {t('auth.profile.updateProfile')}
-          </Button>
-        </CardContent>
-      </Card>
+        <AccordionItem value="notifications" className="border-none">
+          <Card>
+            <CardHeader>
+              <AccordionTrigger className="w-full text-left">
+                <CardTitle>{t('settings.notifications')}</CardTitle>
+              </AccordionTrigger>
+            </CardHeader>
+            <AccordionContent>
+              <CardContent className="flex flex-col gap-4">
+                <div className="flex items-center justify-between">
+                  <span>{t('settings.emailNotifications')}</span>
+                  <Switch
+                    checked={preferences?.emailNotifications}
+                    onCheckedChange={handleToggle('emailNotifications')}
+                  />
+                </div>
+                <div className="flex items-center justify-between">
+                  <span>{t('settings.browserNotifications')}</span>
+                  <Switch
+                    checked={preferences?.browserNotifications}
+                    onCheckedChange={handleToggle('browserNotifications')}
+                  />
+                </div>
+                <div className="flex items-center justify-between">
+                  <span>{t('settings.soundNotifications')}</span>
+                  <Switch
+                    checked={preferences?.soundNotifications}
+                    onCheckedChange={handleToggle('soundNotifications')}
+                  />
+                </div>
+              </CardContent>
+            </AccordionContent>
+          </Card>
+        </AccordionItem>
+
+        <AccordionItem value="appearance" className="border-none">
+          <Card>
+            <CardHeader>
+              <AccordionTrigger className="w-full text-left">
+                <CardTitle>{t('settings.languageAndTheme')}</CardTitle>
+              </AccordionTrigger>
+            </CardHeader>
+            <AccordionContent>
+              <CardContent className="flex items-center gap-4">
+                <LanguageSwitcher />
+                <ThemeToggle />
+              </CardContent>
+            </AccordionContent>
+          </Card>
+        </AccordionItem>
+      </Accordion>
 
       {user && editOpen && (
         <EditUserProfileModal


### PR DESCRIPTION
## Summary
- redesign settings page using accordion structure
- show user's profile info in collapsible section
- add collapsible notification and language/theme sections
- add new i18n keys for new headings

## Testing
- `npm run check`
- `npm run test:api` *(fails: esbuild binary for wrong platform)*

------
https://chatgpt.com/codex/tasks/task_e_685e3c9c5b288320ab28ae045b90bd37