### PR TITLE
Fix preference typing in Settings

### DIFF
--- a/client/src/pages/settings/Settings.tsx
+++ b/client/src/pages/settings/Settings.tsx
@@ -18,7 +18,7 @@ import { ThemeToggle } from '@/components/theme/theme-toggle';
 import { Switch } from '@/components/ui/switch';
 import EditUserProfileModal from '@/components/users/EditUserProfileModal';
 import { useAuth } from '@/hooks/use-auth';
-import { useUserPreferences } from '@/hooks/useUserPreferences';
+import { useUserPreferences, UserPreferences } from '@/hooks/useUserPreferences';
 
 export default function Settings() {
   const { t } = useTranslation();
@@ -26,7 +26,7 @@ export default function Settings() {
   const [editOpen, setEditOpen] = React.useState(false);
   const { preferences, updatePreferences } = useUserPreferences();
 
-  const handleToggle = (field: keyof typeof preferences) => (value: boolean) => {
+  const handleToggle = (field: keyof UserPreferences) => (value: boolean) => {
     updatePreferences({ [field]: value });
   };
 


### PR DESCRIPTION
## Summary
- fix type import in Settings
- use `UserPreferences` keys for `handleToggle`

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_685e428760f88320a47b96ff1d0e59e0