### PR TITLE
Fix settings design details

### DIFF
--- a/client/src/i18n/locales/ru.json
+++ b/client/src/i18n/locales/ru.json
@@ -241,7 +241,7 @@
       "currentPassword": "Текущий пароль",
       "newPassword": "Новый пароль",
       "confirmPassword": "Подтвердите пароль",
-      "updateProfile": "Обновить профиль",
+      "updateProfile": "Редактировать",
       "updateSuccess": "Профиль успешно обновлен",
       "updateError": "Ошибка обновления профиля: {{message}}"
     }

--- a/client/src/pages/settings/Settings.tsx
+++ b/client/src/pages/settings/Settings.tsx
@@ -85,12 +85,10 @@ export default function Settings() {
               <p className="text-sm text-muted-foreground">{t('user.email', 'Электронная почта')}</p>
               <p className="font-medium">{user.email}</p>
             </div>
-            {user.phone && (
-              <div className="space-y-1">
-                <p className="text-sm text-muted-foreground">{t('user.phone', 'Телефон')}</p>
-                <p className="font-medium">{user.phone}</p>
-              </div>
-            )}
+            <div className="space-y-1">
+              <p className="text-sm text-muted-foreground">{t('user.phone', 'Телефон')}</p>
+              <p className="font-medium">{user.phone || '—'}</p>
+            </div>
           </div>
         </div>
       </CardContent>
@@ -102,7 +100,7 @@ export default function Settings() {
               <AccordionTrigger className="w-full text-left">
                 <CardTitle>{t('settings.notifications')}</CardTitle>
               </AccordionTrigger>
-              <AccordionContent>
+              <AccordionContent className="px-6">
                 <div className="flex flex-col gap-4">
                   <div className="flex items-center justify-between">
                     <span>{t('settings.emailNotifications')}</span>
@@ -137,7 +135,7 @@ export default function Settings() {
               <AccordionTrigger className="w-full text-left">
                 <CardTitle>{t('settings.languageAndTheme')}</CardTitle>
               </AccordionTrigger>
-              <AccordionContent>
+              <AccordionContent className="px-6">
                 <div className="flex items-center gap-4">
                   <LanguageSwitcher />
                   <ThemeToggle />


### PR DESCRIPTION
## Summary
- update Russian translation for profile edit action
- show user's phone number with placeholder if absent
- add consistent padding inside settings accordion sections

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_685f9ef19bfc83208edaee5ebe1ee577