### PR TITLE
Fix accordion spacing and profile layout

### DIFF
--- a/client/src/components/ui/accordion.tsx
+++ b/client/src/components/ui/accordion.tsx
@@ -55,7 +55,7 @@ const AccordionTrigger = React.forwardRef<
       ref={ref}
       onClick={toggle}
       className={cn(
-        "flex w-full items-center justify-between py-4 font-medium transition-all hover:underline",
+        "flex w-full items-center justify-between px-6 py-4 font-medium transition-all hover:no-underline",
         className
       )}
       {...props}

--- a/client/src/pages/settings/Settings.tsx
+++ b/client/src/pages/settings/Settings.tsx
@@ -80,14 +80,14 @@ export default function Settings() {
           </CardHeader>
           <CardContent>
         <div className="space-y-3">
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+          <div className="grid grid-cols-1 gap-3">
             <div className="space-y-1">
               <p className="text-sm text-muted-foreground">{t('user.email', 'Электронная почта')}</p>
-              <p className="font-medium">{user.email}</p>
+              <p className="font-medium text-sm">{user.email}</p>
             </div>
             <div className="space-y-1">
               <p className="text-sm text-muted-foreground">{t('user.phone', 'Телефон')}</p>
-              <p className="font-medium">{user.phone || '—'}</p>
+              <p className="font-medium text-sm">{user.phone || '—'}</p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- move phone number under email on settings page
- shrink typography for email and phone
- pad accordion triggers and remove hover underline

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_685fa52643488320b99fbaa62a6999bf