### PR TITLE
Connect notification settings to DB

### DIFF
--- a/client/src/hooks/useUserPreferences.ts
+++ b/client/src/hooks/useUserPreferences.ts
@@ -5,9 +5,14 @@ import { useToast } from '@/hooks/use-toast';
 export interface UserPreferences {
   theme?: string;
   language?: string;
+  notificationsEnabled?: boolean;
+  assignmentNotifications?: boolean;
+  gradeNotifications?: boolean;
+  taskNotifications?: boolean;
+  systemNotifications?: boolean;
+  soundNotifications?: boolean;
   emailNotifications?: boolean;
   browserNotifications?: boolean;
-  soundNotifications?: boolean;
 }
 
 export function useUserPreferences() {
@@ -23,21 +28,34 @@ export function useUserPreferences() {
   const mutation = useMutation({
     mutationFn: async (prefs: Partial<UserPreferences>) =>
       (await apiRequest('/api/user-preferences', 'PUT', prefs)) as UserPreferences,
-    onSuccess: (updated) => {
-      queryClient.setQueryData(['/api/user-preferences'], updated);
+    onMutate: async (prefs: Partial<UserPreferences>) => {
+      await queryClient.cancelQueries({ queryKey: ['/api/user-preferences'] });
+      const previous = queryClient.getQueryData<UserPreferences>(['/api/user-preferences']);
+      queryClient.setQueryData(['/api/user-preferences'], {
+        ...previous,
+        ...prefs,
+      });
+      return { previous };
     },
-    onError: (error: Error) => {
+    onError: (error: Error, _prefs, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(['/api/user-preferences'], context.previous);
+      }
       toast({
         title: 'Error',
         description: error.message,
         variant: 'destructive',
       });
     },
+    onSuccess: (updated) => {
+      queryClient.setQueryData(['/api/user-preferences'], updated);
+      toast({ title: 'Success', description: 'Settings updated successfully' });
+    },
   });
 
   return {
     preferences: data,
     isLoading,
-    updatePreferences: mutation.mutate,
+    updatePreferences: mutation.mutateAsync,
   };
 }

--- a/migrations/003_add_notification_prefs.sql
+++ b/migrations/003_add_notification_prefs.sql
@@ -1,0 +1,6 @@
+ALTER TABLE user_preferences
+  ADD COLUMN IF NOT EXISTS assignment_notifications boolean NOT NULL DEFAULT true,
+  ADD COLUMN IF NOT EXISTS grade_notifications boolean NOT NULL DEFAULT true,
+  ADD COLUMN IF NOT EXISTS task_notifications boolean NOT NULL DEFAULT true,
+  ADD COLUMN IF NOT EXISTS system_notifications boolean NOT NULL DEFAULT true,
+  ADD COLUMN IF NOT EXISTS sound_notifications boolean NOT NULL DEFAULT true;

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -232,6 +232,11 @@ export const userPreferences = pgTable("user_preferences", {
   theme: varchar("theme", { length: 20 }).notNull().default('light'),
   language: varchar("language", { length: 10 }).notNull().default('en'),
   notificationsEnabled: boolean("notifications_enabled").notNull().default(true),
+  assignmentNotifications: boolean("assignment_notifications").notNull().default(true),
+  gradeNotifications: boolean("grade_notifications").notNull().default(true),
+  taskNotifications: boolean("task_notifications").notNull().default(true),
+  systemNotifications: boolean("system_notifications").notNull().default(true),
+  soundNotifications: boolean("sound_notifications").notNull().default(true),
   createdAt: timestamp("created_at").defaultNow(),
   updatedAt: timestamp("updated_at").defaultNow(),
 });


### PR DESCRIPTION
## Summary
- extend `user_preferences` table with per-notification flags
- support optimistic update and success/error toasts in `useUserPreferences`
- persist and restore notification switches on Settings page
- add migration for new preference columns

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_685facad3ca48320bfdeed545ef9857f