### PR TITLE
Add enabled flag to user preferences hook

### DIFF
--- a/client/src/hooks/useUserPreferences.ts
+++ b/client/src/hooks/useUserPreferences.ts
@@ -15,7 +15,7 @@ export interface UserPreferences {
   browserNotifications?: boolean;
 }
 
-export function useUserPreferences() {
+export function useUserPreferences({ enabled = true } = {}) {
   const queryClient = useQueryClient();
   const { toast } = useToast();
 
@@ -23,6 +23,7 @@ export function useUserPreferences() {
     queryKey: ['/api/user-preferences'],
     queryFn: async () =>
       (await apiRequest('/api/user-preferences')) as UserPreferences,
+    enabled,
   });
 
   const mutation = useMutation({

--- a/client/src/pages/settings/Settings.tsx
+++ b/client/src/pages/settings/Settings.tsx
@@ -30,9 +30,10 @@ import { useUserPreferences, UserPreferences } from '@/hooks/useUserPreferences'
 
 export default function Settings() {
   const { t } = useTranslation();
-  const { user } = useAuth();
+  const { user, isLoading: authLoading } = useAuth();
   const [editOpen, setEditOpen] = React.useState(false);
-  const { preferences, isLoading, updatePreferences } = useUserPreferences();
+  const { preferences, isLoading, updatePreferences } =
+    useUserPreferences({ enabled: !!user });
 
 
   const [notificationsEnabled, setNotificationsEnabled] = React.useState(true);
@@ -84,7 +85,7 @@ export default function Settings() {
   };
 
 
-  if (isLoading) {
+  if (authLoading || !user || isLoading) {
     return (
       <div className="py-4 text-center text-muted-foreground">
         {t('common.loading', 'Loading...')}


### PR DESCRIPTION
## Summary
- enhance `useUserPreferences` to accept an `enabled` option for conditional queries
- fetch preferences in Settings page only when a user is loaded
- show fallback UI while authentication or preference loading is pending

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_685fc18fb6288320a8e738850dacc0c0