### PR TITLE
Implement global auth guard

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,27 +1,43 @@
-import React from "react";
-import { Switch, Route } from "wouter";
+import React, { useEffect } from "react";
+import { Switch, Route, useLocation } from "wouter";
 import AuthPage from "@/pages/auth-page";
 import { ProtectedRoute } from "@/lib/protected-route";
 import { useAuth } from "@/hooks/use-auth";
+import { Loader2 } from "lucide-react";
 import routes from "./routes";
+
+const PUBLIC_ROUTES = ["/login", "/register", "/forgot-password"];
 
 
 function App() {
   const { user, isLoading } = useAuth();
-  
-  // Если пользователь не авторизован и загрузка завершена, 
-  // сразу показываем страницу авторизации
-  if (!isLoading && !user) {
-    return <AuthPage />;
+  const [location, setLocation] = useLocation();
+
+  const isPublicRoute = PUBLIC_ROUTES.some((r) => location.startsWith(r));
+
+  useEffect(() => {
+    if (!isLoading && !user && !isPublicRoute) {
+      setLocation('/login');
+    }
+  }, [isLoading, user, isPublicRoute, setLocation]);
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <Loader2 className="h-8 w-8 animate-spin text-border" />
+      </div>
+    );
   }
-  
+
   return (
     <Switch>
-      {routes.map(({ path, component, protected: requiresAuth, adminOnly }, idx) => {
+      {routes.map(({ path, component, adminOnly }, idx) => {
         if (!path) {
           return <Route key={idx} component={component} />;
         }
-        if (requiresAuth) {
+
+        const isPublic = PUBLIC_ROUTES.includes(path);
+        if (!isPublic) {
           return (
             <ProtectedRoute
               key={idx}

--- a/client/src/lib/protected-route.tsx
+++ b/client/src/lib/protected-route.tsx
@@ -22,7 +22,7 @@ export function ProtectedRoute({ path, component: Component, adminOnly = false }
   // Сбрасываем флаг редиректа только при значимых изменениях пути
   useEffect(() => {
     // Проверяем, что изменение пути - это не часть бесконечного цикла
-    if (location !== '/auth' && location !== '/dashboard') {
+    if (location !== '/login' && location !== '/dashboard') {
       setRedirectAttempted(false);
     }
   }, [location]);
@@ -52,11 +52,11 @@ export function ProtectedRoute({ path, component: Component, adminOnly = false }
     }
 
     // Если пользователь не авторизован и это не страница авторизации
-    if (!user && !redirectAttempted && userChanged && location !== '/auth') {
+    if (!user && !redirectAttempted && userChanged && location !== '/login') {
       setRedirectAttempted(true);
-      
+
       // Используем setTimeout для избежания проблем с React 18 StrictMode
-      setTimeout(() => setLocation('/auth'), 0);
+      setTimeout(() => setLocation('/login'), 0);
       return;
     }
   }, [user, isLoading, adminOnly, redirectAttempted, location, setLocation]);
@@ -80,9 +80,9 @@ export function ProtectedRoute({ path, component: Component, adminOnly = false }
     );
   }
 
-  // Если пользователь не авторизован, показываем компонент страницы авторизации
+  // Если пользователь не авторизован, ничего не рендерим
   if (!user) {
-    return <Route path="/auth" component={() => <Component />} />;
+    return null;
   }
 
   // Показываем компонент только если пользователь авторизован и имеет нужные права

--- a/client/src/pages/auth/ForgotPassword.tsx
+++ b/client/src/pages/auth/ForgotPassword.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+export default function ForgotPassword() {
+  const { t } = useTranslation();
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen p-4">
+      <h1 className="text-2xl font-bold mb-2">{t('auth.forgotPassword.title')}</h1>
+      <p className="text-muted-foreground text-center">
+        {t('auth.forgotPassword.subtitle')}
+      </p>
+    </div>
+  );
+}

--- a/client/src/routes.tsx
+++ b/client/src/routes.tsx
@@ -8,6 +8,7 @@ import TasksPage from "@/pages/tasks/Tasks";
 import SettingsPage from "@/pages/settings/Settings";
 import NotFound from "@/pages/not-found";
 import AuthPage from "@/pages/auth-page";
+import ForgotPassword from "@/pages/auth/ForgotPassword";
 import Users from "@/pages/users/Users";
 import UserDetail from "@/pages/users/UserDetail";
 import { MainLayout } from "@/components/layout/main-layout";
@@ -15,7 +16,6 @@ import { MainLayout } from "@/components/layout/main-layout";
 export interface RouteDefinition {
   path?: string;
   component: () => React.JSX.Element;
-  protected?: boolean;
   adminOnly?: boolean;
 }
 
@@ -74,18 +74,20 @@ const ProtectedUserDetail = () => (
 );
 
 export const routes: RouteDefinition[] = [
-  { path: "/auth", component: AuthPage },
-  { path: "/", component: ProtectedDashboard, protected: true },
-  { path: "/dashboard", component: ProtectedDashboard, protected: true },
-  { path: "/assignments", component: ProtectedAssignments, protected: true },
-  { path: "/assignments/:id", component: ProtectedAssignmentDetail, protected: true },
-  { path: "/schedule", component: ProtectedSchedule, protected: true },
-  { path: "/users", component: ProtectedUsers, protected: true, adminOnly: true },
-  { path: "/users/:id", component: ProtectedUserDetail, protected: true, adminOnly: true },
-  { path: "/chat", component: ProtectedChat, protected: true },
-  { path: "/chat/:id", component: ProtectedChat, protected: true },
-  { path: "/tasks", component: ProtectedTasks, protected: true },
-  { path: "/settings", component: ProtectedSettings, protected: true },
+  { path: "/login", component: AuthPage },
+  { path: "/register", component: AuthPage },
+  { path: "/forgot-password", component: ForgotPassword },
+  { path: "/", component: ProtectedDashboard },
+  { path: "/dashboard", component: ProtectedDashboard },
+  { path: "/assignments", component: ProtectedAssignments },
+  { path: "/assignments/:id", component: ProtectedAssignmentDetail },
+  { path: "/schedule", component: ProtectedSchedule },
+  { path: "/users", component: ProtectedUsers, adminOnly: true },
+  { path: "/users/:id", component: ProtectedUserDetail, adminOnly: true },
+  { path: "/chat", component: ProtectedChat },
+  { path: "/chat/:id", component: ProtectedChat },
+  { path: "/tasks", component: ProtectedTasks },
+  { path: "/settings", component: ProtectedSettings },
   { component: NotFound },
 ];
 


### PR DESCRIPTION
## Summary
- add global public route guard with loading state in `App.tsx`
- move protected routing logic to default for all non‑public pages
- update protected route redirect path to `/login`
- register new public routes and placeholder forgot password page

## Testing
- `npm test` *(fails: Missing script)*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_685fcb2376e083209e0f979ef3ac32fd