### PR TITLE
Add phone support to authenticated user

### DIFF
--- a/server/auth.ts
+++ b/server/auth.ts
@@ -172,6 +172,7 @@ export function setupAuth(app: Express) {
       email: req.user.email,
       firstName: req.user.firstName,
       lastName: req.user.lastName,
+      phone: req.user.phone,
       role: req.user.role,
     };
 

--- a/server/middleware/verifySupabaseJwt.ts
+++ b/server/middleware/verifySupabaseJwt.ts
@@ -45,6 +45,7 @@ export async function verifySupabaseJwt(req: Request, res: Response, next: NextF
       email: data.user.email || '',
       firstName: dbUser.firstName,
       lastName: dbUser.lastName,
+      phone: dbUser.phone,
       role: dbUser.role,
     };
 

--- a/server/types/auth.ts
+++ b/server/types/auth.ts
@@ -5,6 +5,7 @@ export interface AuthenticatedUser {
   email: string;
   firstName: string;
   lastName: string;
+  phone?: string;
   role: UserRole;
 }
 

--- a/server/utils/userMapping.ts
+++ b/server/utils/userMapping.ts
@@ -21,6 +21,7 @@ export async function getDbUserBySupabaseUser(
       firstName: user.firstName,
       lastName: user.lastName,
       email: user.email,
+      phone: (user as any).phone,
       role: user.role,
       createdAt: (user as any).createdAt,
       updatedAt: (user as any).updatedAt,

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -21,6 +21,7 @@ export const users = pgTable("users", {
   lastName: text("last_name").notNull(),
   password: text("password").notNull(),
   email: text("email").notNull().unique(),
+  phone: text("phone"),
   role: roleEnum("role").notNull(),
   createdAt: timestamp("created_at").defaultNow(),
 });


### PR DESCRIPTION
## Summary
- include `phone` column in the users table schema
- support optional phone in `AuthenticatedUser` type
- fetch phone in `getDbUserBySupabaseUser`
- populate phone in auth middleware
- return phone from `/api/user`

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6860d791dd608320a5a9a6b6d6c60e88