### PR TITLE
Add phone field to registration form

### DIFF
--- a/client/src/hooks/use-auth.tsx
+++ b/client/src/hooks/use-auth.tsx
@@ -66,6 +66,7 @@ type RegisterData = {
   firstName: string;
   lastName: string;
   email: string;
+  phone?: string;
   password: string;
   role: string;
 };
@@ -218,7 +219,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           data: {
             first_name: userData.firstName,
             last_name: userData.lastName,
-            role: userData.role
+            role: userData.role,
+            phone: userData.phone ?? null
           }
         }
       });

--- a/client/src/pages/auth/Register.tsx
+++ b/client/src/pages/auth/Register.tsx
@@ -28,6 +28,7 @@ export default function Register({ onTabChange }: RegisterProps) {
       password: '',
       confirmPassword: '',
       email: '',
+      phone: '',
       firstName: '',
       lastName: '',
       role: 'student',
@@ -102,22 +103,13 @@ export default function Register({ onTabChange }: RegisterProps) {
             />
             <FormField
               control={form.control}
-              name="role"
+              name="phone"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>{t('auth.register.role')}</FormLabel>
-                  <Select onValueChange={field.onChange} defaultValue={field.value}>
-                    <FormControl>
-                      <SelectTrigger className="glass">
-                        <SelectValue placeholder={t('auth.placeholders.selectRole')} />
-                      </SelectTrigger>
-                    </FormControl>
-                    <SelectContent className="glass-modal">
-                      <SelectItem value="student">{t('users.roles.student')}</SelectItem>
-                      <SelectItem value="teacher">{t('users.roles.teacher')}</SelectItem>
-                      <SelectItem value="admin">{t('users.roles.admin')}</SelectItem>
-                    </SelectContent>
-                  </Select>
+                  <FormLabel>{t('user.phone', 'Телефон')}</FormLabel>
+                  <FormControl>
+                    <Input placeholder="+7 (XXX) XXX-XX-XX" className="glass" {...field} />
+                  </FormControl>
                   <FormMessage />
                 </FormItem>
               )}
@@ -144,6 +136,28 @@ export default function Register({ onTabChange }: RegisterProps) {
                   <FormControl>
                     <Input type="password" placeholder="********" className="glass" {...field} />
                   </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="role"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>{t('auth.register.role')}</FormLabel>
+                  <Select onValueChange={field.onChange} defaultValue={field.value}>
+                    <FormControl>
+                      <SelectTrigger className="glass">
+                        <SelectValue placeholder={t('auth.placeholders.selectRole')} />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent className="glass-modal">
+                      <SelectItem value="student">{t('users.roles.student')}</SelectItem>
+                      <SelectItem value="teacher">{t('users.roles.teacher')}</SelectItem>
+                      <SelectItem value="admin">{t('users.roles.admin')}</SelectItem>
+                    </SelectContent>
+                  </Select>
                   <FormMessage />
                 </FormItem>
               )}

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -105,6 +105,14 @@ export function setupAuth(app: Express) {
       const { data, error } = await supabase.auth.signUp({
         email: validated.email,
         password: validated.password,
+        options: {
+          data: {
+            first_name: validated.firstName,
+            last_name: validated.lastName,
+            role: validated.role,
+            phone: validated.phone ?? null,
+          }
+        }
       });
       if (error || !data.user) {
         return res.status(400).json({ message: error?.message || "Registration failed" });
@@ -115,6 +123,7 @@ export function setupAuth(app: Express) {
         firstName: validated.firstName,
         lastName: validated.lastName,
         email: validated.email,
+        phone: validated.phone,
         password: validated.password,
         role: validated.role,
       });

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -448,6 +448,7 @@ export const registerSchema = z.object({
   firstName: z.string().trim().min(1, "First name is required").max(50, "First name must be at most 50 characters"),
   lastName: z.string().trim().min(1, "Last name is required").max(50, "Last name must be at most 50 characters"),
   email: z.string().trim().email("Valid email is required"),
+  phone: z.string().trim().optional(),
   password: z.string().min(6, "Password must be at least 6 characters"),
   role: z.enum(["student", "teacher", "admin", "director"]),
 });


### PR DESCRIPTION
## Summary
- allow optional phone in shared register schema
- include phone metadata in API registration
- update register form and register mutation to use phone

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6860e3a755788320bd172067dc081235