### PR TITLE
Remove phone from registration

### DIFF
--- a/client/src/hooks/use-auth.tsx
+++ b/client/src/hooks/use-auth.tsx
@@ -66,7 +66,6 @@ type RegisterData = {
   firstName: string;
   lastName: string;
   email: string;
-  phone?: string;
   password: string;
   role: string;
 };
@@ -220,7 +219,6 @@ export function AuthProvider({ children }: { children: ReactNode }) {
             first_name: userData.firstName,
             last_name: userData.lastName,
             role: userData.role,
-            phone: userData.phone ?? null
           }
         }
       });

--- a/client/src/pages/auth/Register.tsx
+++ b/client/src/pages/auth/Register.tsx
@@ -28,7 +28,6 @@ export default function Register({ onTabChange }: RegisterProps) {
       password: '',
       confirmPassword: '',
       email: '',
-      phone: '',
       firstName: '',
       lastName: '',
       role: 'student',
@@ -103,19 +102,6 @@ export default function Register({ onTabChange }: RegisterProps) {
             />
             <FormField
               control={form.control}
-              name="phone"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>{t('user.phone', 'Телефон')}</FormLabel>
-                  <FormControl>
-                    <Input placeholder="+7 (XXX) XXX-XX-XX" className="glass" {...field} />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-            <FormField
-              control={form.control}
               name="password"
               render={({ field }) => (
                 <FormItem>
@@ -162,6 +148,9 @@ export default function Register({ onTabChange }: RegisterProps) {
                 </FormItem>
               )}
             />
+            <p className="text-xs text-muted-foreground">
+              {t('auth.register.phoneLater', 'Телефон можно добавить в настройках профиля')}
+            </p>
             <Button type="submit" className="w-full bg-primary hover:bg-primary/80" disabled={registerMutation.isPending}>
               {registerMutation.isPending ? (
                 <>

--- a/client/src/pages/auth/schema.ts
+++ b/client/src/pages/auth/schema.ts
@@ -7,7 +7,7 @@ export const createLoginSchema = (t: any) => z.object({
 });
 
 export const createRegisterSchema = (t: any) =>
-  insertUserSchema.extend({
+  insertUserSchema.omit({ phone: true }).extend({
     firstName: z.string().min(2, t('auth.validations.firstNameLength')),
     lastName: z.string().min(2, t('auth.validations.lastNameLength')),
     password: z.string().min(6, t('auth.validations.passwordLength')),

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -110,7 +110,6 @@ export function setupAuth(app: Express) {
             first_name: validated.firstName,
             last_name: validated.lastName,
             role: validated.role,
-            phone: validated.phone ?? null,
           }
         }
       });
@@ -123,7 +122,6 @@ export function setupAuth(app: Express) {
         firstName: validated.firstName,
         lastName: validated.lastName,
         email: validated.email,
-        phone: validated.phone,
         password: validated.password,
         role: validated.role,
       });

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -448,7 +448,6 @@ export const registerSchema = z.object({
   firstName: z.string().trim().min(1, "First name is required").max(50, "First name must be at most 50 characters"),
   lastName: z.string().trim().min(1, "Last name is required").max(50, "Last name must be at most 50 characters"),
   email: z.string().trim().email("Valid email is required"),
-  phone: z.string().trim().optional(),
   password: z.string().min(6, "Password must be at least 6 characters"),
   role: z.enum(["student", "teacher", "admin", "director"]),
 });


### PR DESCRIPTION
## Summary
- simplify registration by removing phone number field
- update register schema and validation
- adjust API signup to exclude phone
- tweak register page layout and hint about adding phone later

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6860ed04d67c832095fab7907ba46b13