### PR TITLE
Auto-confirm email when admin creates user

### DIFF
--- a/server/routes/users.ts
+++ b/server/routes/users.ts
@@ -67,6 +67,7 @@ app.post('/api/users', authenticateUser, requireRole(['admin']), async (req, res
     const { data, error } = await supabase.auth.admin.createUser({
       email: userData.email,
       password: userData.password,
+      email_confirm: true,
       user_metadata: {
         first_name: userData.firstName,
         last_name: userData.lastName,


### PR DESCRIPTION
## Summary
- add `email_confirm: true` when creating a user via Supabase admin API so admin-created accounts are pre-confirmed

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_686168a990b883208ae53f3c11005770