### PR TITLE
Use supabase admin delete

### DIFF
--- a/server/db/storage.ts
+++ b/server/db/storage.ts
@@ -26,6 +26,7 @@ import fs from 'fs';
 import path from 'path';
 import { log } from '../vite';
 import { logger } from '../utils/logger';
+import { supabase } from '../supabaseClient';
 
 type EducationLevel = (typeof schema.educationLevelEnum.enumValues)[number];
 
@@ -69,7 +70,12 @@ export class SupabaseStorage {
   }
 
   async deleteUser(id: string): Promise<boolean> {
-    return this.usersRepo.deleteUser(String(id));
+    const { error } = await supabase.auth.admin.deleteUser(id);
+    if (error) {
+      logger.error('Supabase admin deleteUser error:', error);
+      return false;
+    }
+    return true;
   }
 
   async authenticate(credentials: LoginCredentials): Promise<User | undefined> {

--- a/server/routes/users.ts
+++ b/server/routes/users.ts
@@ -234,14 +234,16 @@ app.put('/api/users/:id', authenticateUser, async (req, res) => {
 app.delete('/api/users/:id', authenticateUser, requireRole(['admin']), async (req, res) => {
   try {
     const userId = req.params.id;
-    const success = await getStorage().deleteUser(userId);
-    
-    if (!success) {
-      return res.status(404).json({ message: "User not found" });
+    const { error } = await supabase.auth.admin.deleteUser(userId);
+
+    if (error) {
+      logger.error('Supabase admin deleteUser error:', error);
+      return res.status(400).json({ message: error.message || 'Failed to delete user' });
     }
-    
+
     res.status(204).end();
   } catch (error) {
+    logger.error('Error deleting user:', error);
     res.status(500).json({ message: "Server error" });
   }
 });


### PR DESCRIPTION
## Summary
- hook up admin delete user endpoint to Supabase Auth API
- delegate storage implementation's deleteUser to Supabase

## Testing
- `npm run check`
- `npx tsx server/db/users/repository.test.ts` *(fails: esbuild platform mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68616d755b588320abee3524e89c6a22