### PR TITLE
Clean up unused imports

### DIFF
--- a/client/src/components/dashboards/TeacherDashboard.tsx
+++ b/client/src/components/dashboards/TeacherDashboard.tsx
@@ -8,9 +8,9 @@ import NotificationList from '@/components/notifications/NotificationList';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription, CardFooter } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { 
-  BarChart2, BookOpen, Calendar, Users, 
-  Clock, PenTool, FileText, MessageSquare, 
+import {
+  BarChart2, BookOpen, Calendar, Users,
+  Clock, PenTool, MessageSquare,
   Bell, CheckCircle, XCircle, AlertCircle,
   PlusCircle, FileType
 } from 'lucide-react';

--- a/client/src/components/grades/GradeForm.tsx
+++ b/client/src/components/grades/GradeForm.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { User, Subject, insertGradeSchema } from '@shared/schema';
-import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';

--- a/client/src/components/layout/navbar.tsx
+++ b/client/src/components/layout/navbar.tsx
@@ -4,16 +4,14 @@ import { ThemeToggle } from "@/components/theme/theme-toggle";
 import { LanguageSwitcher } from "@/components/theme/language-switcher";
 import { useAuth } from "@/hooks/use-auth";
 import { Button } from "@/components/ui/button";
-import { 
-  BookOpen, 
-  Calendar, 
-  Award, 
-  Users, 
-  FileText, 
+import {
+  BookOpen,
+  Calendar,
+  Users,
+  FileText,
   MessageSquare,
   LogOut,
-  Menu,
-  X
+  Menu
 } from "lucide-react";
 import {
   Sheet,

--- a/client/src/components/layout/sidebar.tsx
+++ b/client/src/components/layout/sidebar.tsx
@@ -3,12 +3,10 @@ import { Link, useLocation } from "wouter";
 import { useAuth } from "@/hooks/use-auth";
 import { useTranslation } from 'react-i18next';
 import { Button } from "@/components/ui/button";
-import { 
-  FileText as FileManagerIcon, 
-  Calendar, 
-  Award, 
-  Users, 
-  FileText, 
+import {
+  Calendar,
+  Users,
+  FileText,
   MessageSquare,
   LogOut,
   ChevronRight,

--- a/client/src/components/requests/RequestForm.tsx
+++ b/client/src/components/requests/RequestForm.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
-import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';

--- a/client/src/components/schedule/ClassSchedule.tsx
+++ b/client/src/components/schedule/ClassSchedule.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import { ScheduleItem, Subject, User } from '@shared/schema';
 import { formatTime, getDayName } from '@/lib/utils';
-import { Badge } from '@/components/ui/badge';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Book, MapPin, User as UserIcon } from 'lucide-react';
 

--- a/client/src/pages/grades/Grades.tsx
+++ b/client/src/pages/grades/Grades.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from 'react';
+import React, { useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useAuth } from '@/hooks/use-auth';
 


### PR DESCRIPTION
## Summary
- prune unused icons from teacher dashboard
- remove extra icons from navbar and sidebar
- drop unused CardFooter props in grade & request forms
- remove Badge import from class schedule
- drop unused useContext from Grades page

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6862295660748320bf311f7d32b8a4af