### PR TITLE
Remove safe unused imports

### DIFF
--- a/client/src/components/dashboards/AdminDashboard.tsx
+++ b/client/src/components/dashboards/AdminDashboard.tsx
@@ -4,7 +4,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import StatusCard from '@/components/cards/StatusCard';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import { FilePlus, Users, UserCircle, Briefcase, GraduationCap, FileText, MessageSquare, Loader2, ClipboardList, AlertCircle, Clock, CheckCircle, PauseCircle } from 'lucide-react';
+import { Users, UserCircle, Briefcase, GraduationCap, MessageSquare, Loader2, ClipboardList, AlertCircle, Clock, CheckCircle, PauseCircle } from 'lucide-react';
 import { Link } from 'wouter';
 import { User, Request } from '@shared/schema';
 

--- a/client/src/components/notifications/NotificationBell.tsx
+++ b/client/src/components/notifications/NotificationBell.tsx
@@ -3,7 +3,7 @@ import { BellIcon, BellRingIcon, ExternalLinkIcon } from 'lucide-react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '@/hooks/use-auth';
-import { useLocation, useRoute } from 'wouter';
+import { useLocation } from 'wouter';
 import {
   Popover,
   PopoverContent,
@@ -22,7 +22,7 @@ import type { Notification } from '@shared/schema';
 
 export const NotificationBell = () => {
   const { t, i18n } = useTranslation();
-  const { user, isAuthenticated } = useAuth();
+  const { isAuthenticated } = useAuth();
   const queryClient = useQueryClient();
   const [isOpen, setIsOpen] = useState(false);
   const [, setLocation] = useLocation();

--- a/client/src/pages/admin/ImportedFiles.tsx
+++ b/client/src/pages/admin/ImportedFiles.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from '@/components/ui/table';

--- a/client/src/pages/assignments/AssignmentDetail.tsx
+++ b/client/src/pages/assignments/AssignmentDetail.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useParams } from 'wouter';
 import { useAuth } from '@/hooks/use-auth';

--- a/client/src/utils/calendar.ts
+++ b/client/src/utils/calendar.ts
@@ -1,4 +1,4 @@
-import { addWeeks, isBefore, format, addDays, addYears, getDay, setDate, addMonths, eachWeekOfInterval, startOfWeek } from "date-fns";
+import { isBefore, format, addDays, getDay, addMonths, eachWeekOfInterval } from "date-fns";
 import { ru } from "date-fns/locale/ru";
 import { getWeeksInYear } from "./getWeeksInYear";
 


### PR DESCRIPTION
## Summary
- clean unused icons in AdminDashboard
- drop unused `useRoute` hook and user variable in NotificationBell
- remove dead date-fns utilities in calendar helper
- trim extra hooks from ImportedFiles admin page
- tidy AssignmentDetail import list

## Testing
- `npx tsc -p tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68622b8c6f0883209b5cf5a9b801a9d1