### PR TITLE
Fix orphan refetchGrades call

### DIFF
--- a/client/src/components/dashboards/StudentDashboard.tsx
+++ b/client/src/components/dashboards/StudentDashboard.tsx
@@ -12,7 +12,7 @@ import {
 } from 'lucide-react';
 import { Link } from 'wouter';
 import { Badge } from '@/components/ui/badge';
-import { Assignment, Notification, Request, Grade, Submission } from '@shared/schema';
+import { Assignment, Notification, Request, Submission } from '@shared/schema';
 import { apiRequest } from '@/lib/queryClient';
 import { useAuth } from '@/hooks/use-auth';
 import DashboardSkeleton from './DashboardSkeleton';
@@ -152,7 +152,6 @@ const StudentDashboard = () => {
   if (error) {
     const handleRetry = () => {
       refetchAssignments();
-      refetchGrades();
       refetchSchedule();
       refetchNotifications();
       refetchRequests();


### PR DESCRIPTION
## Summary
- remove unused `Grade` import
- remove stale `refetchGrades()` call from error retry handler

## Testing
- `npx tsc -p tsconfig.json --noEmit --noUnusedLocals` *(fails: unused imports etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68624287b1048320bb9f97e33f5eae3c