### PR TITLE
Fix StudentDocuments props

### DIFF
--- a/client/src/pages/students/StudentDetail.tsx
+++ b/client/src/pages/students/StudentDetail.tsx
@@ -135,8 +135,7 @@ export default function StudentDetail() {
               <div key="documents-container">
                 {(() => {
                   const DocumentsComponent = React.lazy(() => import('@/components/students/StudentDocuments'));
-                  return <DocumentsComponent 
-                    userId={userId}
+                  return <DocumentsComponent
                     documents={[]} // В будущем будем получать из API
                     isLoading={false}
                   />;


### PR DESCRIPTION
## Summary
- remove `userId` prop from `StudentDocuments` usage in `StudentDetail`

## Testing
- `npm run check`
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_6862459c15e88320b6fe4573f553eff3