### PR TITLE
Remove unused props from user card components

### DIFF
--- a/client/src/components/users/AdminCard.tsx
+++ b/client/src/components/users/AdminCard.tsx
@@ -28,7 +28,6 @@ const AdminCard: React.FC<AdminCardProps> = ({ admin, onClick, onEdit }) => {
   const { t } = useTranslation();
 
   const {
-    id,
     firstName,
     lastName,
     email,

--- a/client/src/components/users/DirectorCard.tsx
+++ b/client/src/components/users/DirectorCard.tsx
@@ -30,7 +30,6 @@ const DirectorCard: React.FC<DirectorCardProps> = ({ director, onClick, onEdit }
   const { t } = useTranslation();
 
   const {
-    id,
     firstName,
     lastName,
     email,

--- a/client/src/components/users/StudentCard.tsx
+++ b/client/src/components/users/StudentCard.tsx
@@ -18,7 +18,6 @@ import {
   ClipboardList,
   Bell,
   BarChart2,
-  UserCheck,
   MapPin,
   GraduationCap,
   FileText,

--- a/client/src/components/users/TeacherCard.tsx
+++ b/client/src/components/users/TeacherCard.tsx
@@ -54,7 +54,6 @@ const TeacherCard: React.FC<TeacherCardProps> = ({ teacher, onClick, onEdit }) =
   };
 
   const {
-    id,
     firstName,
     lastName,
     email,

--- a/client/src/components/users/UserCard.tsx
+++ b/client/src/components/users/UserCard.tsx
@@ -25,7 +25,6 @@ const UserCard: React.FC<UserCardProps> = ({ user, onClick }) => {
   const { t } = useTranslation();
 
   const {
-    id,
     firstName,
     lastName,
     email,


### PR DESCRIPTION
## Summary
- clean up user card components by removing unused `id` fields
- remove unused icon import in StudentCard

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68624cb8b65083209ee8ef895eff3617