### PR TITLE
Add abort signal support

### DIFF
--- a/client/src/hooks/use-auth.tsx
+++ b/client/src/hooks/use-auth.tsx
@@ -147,7 +147,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   });
 
   const loginMutation = useMutation({
-    mutationFn: async (credentials: LoginData) => {
+    mutationFn: async (credentials: LoginData, { signal }) => {
       const { error } = await supabase.auth.signInWithPassword(credentials);
       if (error) {
         throw new Error(error.message);
@@ -174,7 +174,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         headers: fetchOptions.headers,
       });
 
-      const res = await authFetch("/api/user", fetchOptions);
+      const res = await authFetch("/api/user", { ...fetchOptions, signal });
       if (!res.ok) {
         throw new Error('Failed to fetch user data');
       }
@@ -209,7 +209,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   });
 
   const registerMutation = useMutation({
-    mutationFn: async (userData: RegisterData) => {
+    mutationFn: async (userData: RegisterData, { signal }) => {
       const { email, password } = userData;
       const { error } = await supabase.auth.signUp({
         email,
@@ -247,7 +247,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         headers: fetchOptions.headers,
       });
 
-      const res = await authFetch('/api/user', fetchOptions);
+      const res = await authFetch('/api/user', { ...fetchOptions, signal });
       if (!res.ok) {
         throw new Error('Failed to fetch user data');
       }

--- a/client/src/hooks/useUserPreferences.ts
+++ b/client/src/hooks/useUserPreferences.ts
@@ -27,8 +27,8 @@ export function useUserPreferences({ enabled = true } = {}) {
   });
 
   const mutation = useMutation({
-    mutationFn: async (prefs: Partial<UserPreferences>) =>
-      (await apiRequest('/api/user-preferences', 'PUT', prefs)) as UserPreferences,
+    mutationFn: async (prefs: Partial<UserPreferences>, { signal }) =>
+      (await apiRequest('/api/user-preferences', 'PUT', prefs, signal)) as UserPreferences,
     onMutate: async (prefs: Partial<UserPreferences>) => {
       await queryClient.cancelQueries({ queryKey: ['/api/user-preferences'] });
       const previous = queryClient.getQueryData<UserPreferences>(['/api/user-preferences']);

--- a/client/src/pages/assignments/AssignmentDetail.tsx
+++ b/client/src/pages/assignments/AssignmentDetail.tsx
@@ -51,10 +51,10 @@ const AssignmentDetail = () => {
   
   // Mutation for submitting assignment (student)
   const submitAssignmentMutation = useMutation({
-    mutationFn: (formData: FormData) => {
+    mutationFn: (formData: FormData, { signal }) => {
       formData.append('assignmentId', assignmentId.toString());
       formData.append('content', 'Submitted via file upload');
-      return uploadFile('/api/submissions', formData);
+      return uploadFile('/api/submissions', formData, signal);
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [`/api/submissions/assignment/${assignmentId}`] });
@@ -75,8 +75,11 @@ const AssignmentDetail = () => {
   
   // Mutation for grading assignment (teacher)
   const gradeAssignmentMutation = useMutation({
-    mutationFn: ({ submissionId, grade, feedback }: { submissionId: string; grade: number; feedback: string }) => {
-      return putData(`/api/submissions/${submissionId}/grade`, { grade, feedback });
+    mutationFn: (
+      { submissionId, grade, feedback }: { submissionId: string; grade: number; feedback: string },
+      { signal },
+    ) => {
+      return putData(`/api/submissions/${submissionId}/grade`, { grade, feedback }, signal);
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [`/api/submissions/assignment/${assignmentId}`] });

--- a/client/src/pages/assignments/useAssignments.ts
+++ b/client/src/pages/assignments/useAssignments.ts
@@ -52,11 +52,12 @@ export function useAssignments() {
     Error,
     z.infer<typeof createAssignmentSchema>
   >({
-    mutationFn: async (data: z.infer<typeof createAssignmentSchema>) => {
+    mutationFn: async (data: z.infer<typeof createAssignmentSchema>, { signal }) => {
       const response = await authFetch('/api/assignments', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ ...data, teacherId: user!.id }),
+        signal,
       });
       if (!response.ok) {
         const errorData = await response.json();
@@ -78,11 +79,12 @@ export function useAssignments() {
     Error,
     z.infer<typeof submitAssignmentSchema> & { assignmentId: string }
   >({
-    mutationFn: async (data) => {
+    mutationFn: async (data, { signal }) => {
       const response = await authFetch('/api/submissions', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ ...data, studentId: user!.id }),
+        signal,
       });
       if (!response.ok) {
         const errorData = await response.json();

--- a/client/src/pages/curriculum/CurriculumPlans.tsx
+++ b/client/src/pages/curriculum/CurriculumPlans.tsx
@@ -61,8 +61,8 @@ export default function CurriculumPlans() {
 
   // Мутация для создания нового учебного плана
   const createMutation = useMutation({
-    mutationFn: (newPlan: CurriculumFormValues) =>
-      apiRequest('/api/curriculum-plans', 'POST', JSON.stringify(newPlan)),
+    mutationFn: (newPlan: CurriculumFormValues, { signal }) =>
+      apiRequest('/api/curriculum-plans', 'POST', JSON.stringify(newPlan), signal),
     onSuccess: () => {
       toast({
         title: "Учебный план создан",
@@ -84,9 +84,9 @@ export default function CurriculumPlans() {
 
   // Мутация для обновления учебного плана
   const updateMutation = useMutation({
-    mutationFn: (updatedPlan: Partial<CurriculumFormValues> & { id: string }) => {
+    mutationFn: (updatedPlan: Partial<CurriculumFormValues> & { id: string }, { signal }) => {
       const { id, ...planData } = updatedPlan;
-      return apiRequest(`/api/curriculum-plans/${id}`, 'PUT', JSON.stringify(planData));
+      return apiRequest(`/api/curriculum-plans/${id}`, 'PUT', JSON.stringify(planData), signal);
     },
     onSuccess: () => {
       toast({
@@ -109,8 +109,8 @@ export default function CurriculumPlans() {
 
   // Мутация для удаления учебного плана
   const deleteMutation = useMutation({
-    mutationFn: (id: string) =>
-      apiRequest(`/api/curriculum-plans/${id}`, 'DELETE'),
+    mutationFn: (id: string, { signal }) =>
+      apiRequest(`/api/curriculum-plans/${id}`, 'DELETE', undefined, signal),
     onSuccess: () => {
       toast({
         title: "Учебный план удален",

--- a/client/src/pages/curriculum/EditCurriculumPlan.tsx
+++ b/client/src/pages/curriculum/EditCurriculumPlan.tsx
@@ -141,14 +141,17 @@ function EditCurriculumPlanContent(): React.ReactNode {
 
   // Мутация для обновления учебного плана (унифицированная версия)
   const updateMutation = useMutation({
-    mutationFn: (updatedPlan: Partial<CurriculumFormValues> & {
+    mutationFn: (
+      updatedPlan: Partial<CurriculumFormValues> & {
       id: string,
       calendarData?: string,
       curriculumPlanData?: string,
       // Новые поля для унифицированного сохранения
       calendarJson?: string,
       planJson?: string
-    }) => {
+    },
+      { signal },
+    ) => {
       const { id, ...planData } = updatedPlan;
 
       // Сохраняем текущие данные yearsOfStudy для синхронизации между компонентами
@@ -204,7 +207,7 @@ function EditCurriculumPlanContent(): React.ReactNode {
       }
 
       // Используем PATCH метод для унифицированного сохранения
-      return apiRequest(`/api/curriculum-plans/${id}`, 'PATCH', JSON.stringify(planData));
+      return apiRequest(`/api/curriculum-plans/${id}`, 'PATCH', JSON.stringify(planData), signal);
     },
     onSuccess: (data) => {
       toast({

--- a/client/src/pages/documents/DocumentPage.tsx
+++ b/client/src/pages/documents/DocumentPage.tsx
@@ -55,7 +55,8 @@ export default function DocumentPage({ documentType, title, icon: Icon }: Docume
   });
 
   const createDocumentMutation = useMutation({
-    mutationFn: (formData: FormData) => uploadFile('/api/documents', formData),
+    mutationFn: (formData: FormData, { signal }) =>
+      uploadFile('/api/documents', formData, signal),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['/api/documents'] });
       const capitalized = documentType.charAt(0).toUpperCase() + documentType.slice(1);

--- a/client/src/pages/grades/Grades.tsx
+++ b/client/src/pages/grades/Grades.tsx
@@ -40,8 +40,8 @@ const Grades = () => {
   
   // Mutation for creating grades
   const createGradeMutation = useMutation({
-    mutationFn: (data: z.infer<typeof insertGradeSchema>) => {
-      return postData('/api/grades', data);
+    mutationFn: (data: z.infer<typeof insertGradeSchema>, { signal }) => {
+      return postData('/api/grades', data, signal);
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['/api/grades'] });

--- a/client/src/pages/requests/Requests.tsx
+++ b/client/src/pages/requests/Requests.tsx
@@ -45,8 +45,8 @@ const Requests = () => {
     Error,
     RequestFormData
   >({
-    mutationFn: (data: RequestFormData) => {
-      return postData('/api/requests', data);
+    mutationFn: (data: RequestFormData, { signal }) => {
+      return postData('/api/requests', data, signal);
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [`/api/requests/student/${user?.id}`] });
@@ -70,8 +70,8 @@ const Requests = () => {
     Error,
     { requestId: string; status: 'approved' | 'rejected'; resolution: string }
   >({
-    mutationFn: ({ requestId, status, resolution }: { requestId: string; status: 'approved' | 'rejected'; resolution: string }) => {
-      return putData(`/api/requests/${requestId}/status`, { status, resolution });
+    mutationFn: ({ requestId, status, resolution }: { requestId: string; status: 'approved' | 'rejected'; resolution: string }, { signal }) => {
+      return putData(`/api/requests/${requestId}/status`, { status, resolution }, signal);
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['/api/requests'] });

--- a/client/src/pages/tasks/useTasks.ts
+++ b/client/src/pages/tasks/useTasks.ts
@@ -83,8 +83,8 @@ export function useTasks() {
   });
 
   const createTaskMutation = useMutation({
-    mutationFn: async (data: InsertTask) => {
-      const result = await apiRequest('/api/tasks', 'POST', data);
+    mutationFn: async (data: InsertTask, { signal }) => {
+      const result = await apiRequest('/api/tasks', 'POST', data, signal);
       return result;
     },
     onSuccess: () => {
@@ -105,8 +105,8 @@ export function useTasks() {
   });
 
   const updateTaskStatusMutation = useMutation({
-    mutationFn: async ({ id, status }: { id: number; status: string }) => {
-      const result = await apiRequest(`/api/tasks/${id}/status`, 'PATCH', { status });
+    mutationFn: async ({ id, status }: { id: number; status: string }, { signal }) => {
+      const result = await apiRequest(`/api/tasks/${id}/status`, 'PATCH', { status }, signal);
       return result;
     },
     onSuccess: () => {
@@ -132,8 +132,8 @@ export function useTasks() {
   });
 
   const deleteTaskMutation = useMutation({
-    mutationFn: async (id: number) => {
-      const result = await apiRequest(`/api/tasks/${id}`, 'DELETE');
+    mutationFn: async (id: number, { signal }) => {
+      const result = await apiRequest(`/api/tasks/${id}`, 'DELETE', undefined, signal);
       return result;
     },
     onSuccess: () => {
@@ -154,7 +154,8 @@ export function useTasks() {
   });
 
   const updateTaskMutation = useMutation({
-    mutationFn: async (data: {
+    mutationFn: async (
+      data: {
       id: number;
       title?: string;
       description?: string;
@@ -162,9 +163,11 @@ export function useTasks() {
       priority?: string;
       dueDate?: string | null;
       executorId?: string;
-    }) => {
+    },
+      { signal },
+    ) => {
       const { id, ...taskData } = data;
-      const result = await apiRequest(`/api/tasks/${id}`, 'PUT', taskData);
+      const result = await apiRequest(`/api/tasks/${id}`, 'PUT', taskData, signal);
       return result;
     },
     onSuccess: () => {

--- a/client/src/pages/users/Users.tsx
+++ b/client/src/pages/users/Users.tsx
@@ -125,8 +125,8 @@ export default function Users() {
 
   // Create user mutation
   const createUserMutation = useMutation({
-    mutationFn: async (userData: InsertUser) => {
-      return await apiRequest('/api/users', 'POST', userData) as User;
+    mutationFn: async (userData: InsertUser, { signal }) => {
+      return await apiRequest('/api/users', 'POST', userData, signal) as User;
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['/api/users'] });
@@ -148,8 +148,8 @@ export default function Users() {
 
   // Update user mutation
   const updateUserMutation = useMutation({
-    mutationFn: async ({ id, userData }: { id: string, userData: Partial<InsertUser> }) => {
-      return await apiRequest(`/api/users/${id}`, 'PUT', userData) as User;
+    mutationFn: async ({ id, userData }: { id: string, userData: Partial<InsertUser> }, { signal }) => {
+      return await apiRequest(`/api/users/${id}`, 'PUT', userData, signal) as User;
     },
     onSuccess: () => {
       // Инвалидируем запросы пользователей и уведомлений для немедленного обновления UI
@@ -174,8 +174,8 @@ export default function Users() {
 
   // Delete user mutation
   const deleteUserMutation = useMutation({
-    mutationFn: async (id: string) => {
-      await apiRequest(`/api/users/${id}`, 'DELETE');
+    mutationFn: async (id: string, { signal }) => {
+      await apiRequest(`/api/users/${id}`, 'DELETE', undefined, signal);
       return Promise.resolve();
     },
     onSuccess: () => {


### PR DESCRIPTION
## Summary
- forward query abort signals in getQueryFn
- add optional signal param to authFetch and api helpers
- pass signal to fetches in various mutation functions

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_686259b387ec8320997bf2ae24c022ba