### PR TITLE
Watch auth user for logout

### DIFF
--- a/client/src/pages/settings/Settings.tsx
+++ b/client/src/pages/settings/Settings.tsx
@@ -54,6 +54,18 @@ export default function Settings() {
     }
   }, [preferences]);
 
+  // Reset local notification state when user logs out
+  React.useEffect(() => {
+    if (!user) {
+      setNotificationsEnabled(true);
+      setAssignmentNotifications(true);
+      setGradeNotifications(true);
+      setTaskNotifications(true);
+      setSystemNotifications(true);
+      setSoundNotifications(true);
+    }
+  }, [user]);
+
   const roleIcons: Record<string, JSX.Element> = {
     student: <User className="h-3.5 w-3.5 mr-1" />,
     teacher: <GraduationCap className="h-3.5 w-3.5 mr-1" />,


### PR DESCRIPTION
## Summary
- watch the `user` from `useAuth` in Settings
- reset notification toggles when the user becomes null

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68625e40f9e483209f1f993c29a438e6