### PR TITLE
Fix mutation params

### DIFF
--- a/client/src/hooks/use-auth.tsx
+++ b/client/src/hooks/use-auth.tsx
@@ -147,7 +147,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   });
 
   const loginMutation = useMutation({
-    mutationFn: async (credentials: LoginData, { signal }) => {
+    mutationFn: async (credentials: LoginData, { signal } = {}) => {
       const { error } = await supabase.auth.signInWithPassword(credentials);
       if (error) {
         throw new Error(error.message);
@@ -209,7 +209,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   });
 
   const registerMutation = useMutation({
-    mutationFn: async (userData: RegisterData, { signal }) => {
+    mutationFn: async (userData: RegisterData, { signal } = {}) => {
       const { email, password } = userData;
       const { error } = await supabase.auth.signUp({
         email,

--- a/client/src/hooks/useUserPreferences.ts
+++ b/client/src/hooks/useUserPreferences.ts
@@ -27,7 +27,7 @@ export function useUserPreferences({ enabled = true } = {}) {
   });
 
   const mutation = useMutation({
-    mutationFn: async (prefs: Partial<UserPreferences>, { signal }) =>
+    mutationFn: async (prefs: Partial<UserPreferences>, { signal } = {}) =>
       (await apiRequest('/api/user-preferences', 'PUT', prefs, signal)) as UserPreferences,
     onMutate: async (prefs: Partial<UserPreferences>) => {
       await queryClient.cancelQueries({ queryKey: ['/api/user-preferences'] });

--- a/client/src/pages/assignments/AssignmentDetail.tsx
+++ b/client/src/pages/assignments/AssignmentDetail.tsx
@@ -51,7 +51,7 @@ const AssignmentDetail = () => {
   
   // Mutation for submitting assignment (student)
   const submitAssignmentMutation = useMutation({
-    mutationFn: (formData: FormData, { signal }) => {
+    mutationFn: (formData: FormData, { signal } = {}) => {
       formData.append('assignmentId', assignmentId.toString());
       formData.append('content', 'Submitted via file upload');
       return uploadFile('/api/submissions', formData, signal);
@@ -77,7 +77,7 @@ const AssignmentDetail = () => {
   const gradeAssignmentMutation = useMutation({
     mutationFn: (
       { submissionId, grade, feedback }: { submissionId: string; grade: number; feedback: string },
-      { signal },
+      { signal } = {},
     ) => {
       return putData(`/api/submissions/${submissionId}/grade`, { grade, feedback }, signal);
     },

--- a/client/src/pages/assignments/useAssignments.ts
+++ b/client/src/pages/assignments/useAssignments.ts
@@ -52,7 +52,7 @@ export function useAssignments() {
     Error,
     z.infer<typeof createAssignmentSchema>
   >({
-    mutationFn: async (data: z.infer<typeof createAssignmentSchema>, { signal }) => {
+    mutationFn: async (data: z.infer<typeof createAssignmentSchema>, { signal } = {}) => {
       const response = await authFetch('/api/assignments', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -79,7 +79,7 @@ export function useAssignments() {
     Error,
     z.infer<typeof submitAssignmentSchema> & { assignmentId: string }
   >({
-    mutationFn: async (data, { signal }) => {
+    mutationFn: async (data, { signal } = {}) => {
       const response = await authFetch('/api/submissions', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },

--- a/client/src/pages/curriculum/CurriculumPlans.tsx
+++ b/client/src/pages/curriculum/CurriculumPlans.tsx
@@ -61,7 +61,7 @@ export default function CurriculumPlans() {
 
   // Мутация для создания нового учебного плана
   const createMutation = useMutation({
-    mutationFn: (newPlan: CurriculumFormValues, { signal }) =>
+    mutationFn: (newPlan: CurriculumFormValues, { signal } = {}) =>
       apiRequest('/api/curriculum-plans', 'POST', JSON.stringify(newPlan), signal),
     onSuccess: () => {
       toast({
@@ -84,7 +84,10 @@ export default function CurriculumPlans() {
 
   // Мутация для обновления учебного плана
   const updateMutation = useMutation({
-    mutationFn: (updatedPlan: Partial<CurriculumFormValues> & { id: string }, { signal }) => {
+    mutationFn: (
+      updatedPlan: Partial<CurriculumFormValues> & { id: string },
+      { signal } = {}
+    ) => {
       const { id, ...planData } = updatedPlan;
       return apiRequest(`/api/curriculum-plans/${id}`, 'PUT', JSON.stringify(planData), signal);
     },
@@ -109,7 +112,7 @@ export default function CurriculumPlans() {
 
   // Мутация для удаления учебного плана
   const deleteMutation = useMutation({
-    mutationFn: (id: string, { signal }) =>
+    mutationFn: (id: string, { signal } = {}) =>
       apiRequest(`/api/curriculum-plans/${id}`, 'DELETE', undefined, signal),
     onSuccess: () => {
       toast({

--- a/client/src/pages/curriculum/EditCurriculumPlan.tsx
+++ b/client/src/pages/curriculum/EditCurriculumPlan.tsx
@@ -150,7 +150,7 @@ function EditCurriculumPlanContent(): React.ReactNode {
       calendarJson?: string,
       planJson?: string
     },
-      { signal },
+      { signal } = {},
     ) => {
       const { id, ...planData } = updatedPlan;
 

--- a/client/src/pages/documents/DocumentPage.tsx
+++ b/client/src/pages/documents/DocumentPage.tsx
@@ -55,7 +55,7 @@ export default function DocumentPage({ documentType, title, icon: Icon }: Docume
   });
 
   const createDocumentMutation = useMutation({
-    mutationFn: (formData: FormData, { signal }) =>
+    mutationFn: (formData: FormData, { signal } = {}) =>
       uploadFile('/api/documents', formData, signal),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['/api/documents'] });

--- a/client/src/pages/grades/Grades.tsx
+++ b/client/src/pages/grades/Grades.tsx
@@ -40,7 +40,7 @@ const Grades = () => {
   
   // Mutation for creating grades
   const createGradeMutation = useMutation({
-    mutationFn: (data: z.infer<typeof insertGradeSchema>, { signal }) => {
+    mutationFn: (data: z.infer<typeof insertGradeSchema>, { signal } = {}) => {
       return postData('/api/grades', data, signal);
     },
     onSuccess: () => {

--- a/client/src/pages/requests/Requests.tsx
+++ b/client/src/pages/requests/Requests.tsx
@@ -45,7 +45,7 @@ const Requests = () => {
     Error,
     RequestFormData
   >({
-    mutationFn: (data: RequestFormData, { signal }) => {
+    mutationFn: (data: RequestFormData, { signal } = {}) => {
       return postData('/api/requests', data, signal);
     },
     onSuccess: () => {
@@ -70,7 +70,10 @@ const Requests = () => {
     Error,
     { requestId: string; status: 'approved' | 'rejected'; resolution: string }
   >({
-    mutationFn: ({ requestId, status, resolution }: { requestId: string; status: 'approved' | 'rejected'; resolution: string }, { signal }) => {
+    mutationFn: (
+      { requestId, status, resolution }: { requestId: string; status: 'approved' | 'rejected'; resolution: string },
+      { signal } = {}
+    ) => {
       return putData(`/api/requests/${requestId}/status`, { status, resolution }, signal);
     },
     onSuccess: () => {

--- a/client/src/pages/tasks/useTasks.ts
+++ b/client/src/pages/tasks/useTasks.ts
@@ -83,7 +83,7 @@ export function useTasks() {
   });
 
   const createTaskMutation = useMutation({
-    mutationFn: async (data: InsertTask, { signal }) => {
+    mutationFn: async (data: InsertTask, { signal } = {}) => {
       const result = await apiRequest('/api/tasks', 'POST', data, signal);
       return result;
     },
@@ -105,7 +105,10 @@ export function useTasks() {
   });
 
   const updateTaskStatusMutation = useMutation({
-    mutationFn: async ({ id, status }: { id: number; status: string }, { signal }) => {
+    mutationFn: async (
+      { id, status }: { id: number; status: string },
+      { signal } = {}
+    ) => {
       const result = await apiRequest(`/api/tasks/${id}/status`, 'PATCH', { status }, signal);
       return result;
     },
@@ -132,7 +135,7 @@ export function useTasks() {
   });
 
   const deleteTaskMutation = useMutation({
-    mutationFn: async (id: number, { signal }) => {
+    mutationFn: async (id: number, { signal } = {}) => {
       const result = await apiRequest(`/api/tasks/${id}`, 'DELETE', undefined, signal);
       return result;
     },
@@ -164,7 +167,7 @@ export function useTasks() {
       dueDate?: string | null;
       executorId?: string;
     },
-      { signal },
+      { signal } = {},
     ) => {
       const { id, ...taskData } = data;
       const result = await apiRequest(`/api/tasks/${id}`, 'PUT', taskData, signal);

--- a/client/src/pages/users/Users.tsx
+++ b/client/src/pages/users/Users.tsx
@@ -125,7 +125,7 @@ export default function Users() {
 
   // Create user mutation
   const createUserMutation = useMutation({
-    mutationFn: async (userData: InsertUser, { signal }) => {
+    mutationFn: async (userData: InsertUser, { signal } = {}) => {
       return await apiRequest('/api/users', 'POST', userData, signal) as User;
     },
     onSuccess: () => {
@@ -148,7 +148,10 @@ export default function Users() {
 
   // Update user mutation
   const updateUserMutation = useMutation({
-    mutationFn: async ({ id, userData }: { id: string, userData: Partial<InsertUser> }, { signal }) => {
+    mutationFn: async (
+      { id, userData }: { id: string, userData: Partial<InsertUser> },
+      { signal } = {}
+    ) => {
       return await apiRequest(`/api/users/${id}`, 'PUT', userData, signal) as User;
     },
     onSuccess: () => {
@@ -174,7 +177,7 @@ export default function Users() {
 
   // Delete user mutation
   const deleteUserMutation = useMutation({
-    mutationFn: async (id: string, { signal }) => {
+    mutationFn: async (id: string, { signal } = {}) => {
       await apiRequest(`/api/users/${id}`, 'DELETE', undefined, signal);
       return Promise.resolve();
     },


### PR DESCRIPTION
## Summary
- handle missing `signal` argument with default destructuring in many mutation hooks

## Testing
- `npx tsc -p tsconfig.check.json`

------
https://chatgpt.com/codex/tasks/task_e_6862d32a7b6083208b4142598d6ff23f