### PR TITLE
Implement unified profile update

### DIFF
--- a/client/src/components/users/EditUserProfileModal.tsx
+++ b/client/src/components/users/EditUserProfileModal.tsx
@@ -135,9 +135,12 @@ const EditUserProfileModal: React.FC<EditUserProfileModalProps> = ({
         lastName: data.lastName,
         email: data.email,
       };
-      
-      // Добавляем только нужные поля в зависимости от роли
+
+      // Дополнительные поля профиля
       if (data.phone) formData.phone = data.phone;
+      if (data.group) formData.group = data.group;
+      if (data.major) formData.major = data.major;
+      if (data.course) formData.course = data.course;
 
       // Добавим предотвращение кеширования
       const cacheBuster = `?_t=${Date.now()}`;
@@ -158,21 +161,8 @@ const EditUserProfileModal: React.FC<EditUserProfileModalProps> = ({
       }
 
       // Обновляем дополнительные данные в зависимости от роли
-      // Для студента
-      if (data.role === 'student' && (data.group || data.major || data.course)) {
-        const studentData: Record<string, any> = {};
-        if (data.group) studentData.group = data.group;
-        if (data.major) studentData.major = data.major;
-        if (data.course) studentData.course = data.course;
-
-        try {
-          await apiRequest(`/api/students/${user.id}`, 'PUT', studentData);
-        } catch {
-          // Обработка ошибки обновления данных студента, но продолжаем работу
-        }
-      }
       // Для преподавателя
-      else if (data.role === 'teacher' && (data.specialty || data.experience)) {
+      if (data.role === 'teacher' && (data.specialty || data.experience)) {
         const teacherData: Record<string, any> = {};
         if (data.specialty) teacherData.specialty = data.specialty;
         if (data.experience) teacherData.experience = data.experience;
@@ -184,7 +174,7 @@ const EditUserProfileModal: React.FC<EditUserProfileModalProps> = ({
         }
       }
       // Для админа или директора
-      else if ((data.role === 'admin' || data.role === 'director') && 
+      if ((data.role === 'admin' || data.role === 'director') &&
                (data.department || data.title || data.organization)) {
         const adminData: Record<string, any> = {};
         if (data.department) adminData.department = data.department;

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -22,6 +22,9 @@ export const users = pgTable("users", {
   password: text("password").notNull(),
   email: text("email").notNull().unique(),
   phone: text("phone"),
+  group: text("group"),
+  major: text("major"),
+  course: integer("course"),
   role: roleEnum("role").notNull(),
   createdAt: timestamp("created_at").defaultNow(),
 });
@@ -262,9 +265,13 @@ export const curriculumPlans = pgTable("curriculum_plans", {
 });
 
 // Insert Schemas
-export const insertUserSchema = createInsertSchema(users).omit({ 
+export const insertUserSchema = createInsertSchema(users).omit({
   id: true,
   createdAt: true
+}).extend({
+  group: z.string().optional(),
+  major: z.string().optional(),
+  course: z.number().int().optional(),
 });
 
 export const insertSubjectSchema = createInsertSchema(subjects).omit({


### PR DESCRIPTION
## Summary
- support `group`, `major` and `course` on `users` table and insert schema
- send these profile fields directly to `/api/users/:id`

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68637b56b874832086e2b3176b48f141