### PR TITLE
Implement group_name field

### DIFF
--- a/client/src/components/students/EditStudentProfileModal.tsx
+++ b/client/src/components/students/EditStudentProfileModal.tsx
@@ -34,7 +34,7 @@ interface StudentProfile {
   lastName: string;
   email: string;
   phone?: string;
-  group?: string;
+  group_name?: string;
   major?: string;
   course?: number;
 }
@@ -61,7 +61,7 @@ const EditStudentProfileModal: React.FC<EditStudentProfileModalProps> = ({
     lastName: z.string().min(1, 'Фамилия обязательна для заполнения'),
     email: z.string().email('Введите корректный email'),
     phone: z.string().optional(),
-    group: z.string().optional(),
+    group_name: z.string().optional(),
     major: z.string().optional(),
     course: z.coerce.number().int().positive().optional(),
   });
@@ -77,7 +77,7 @@ const EditStudentProfileModal: React.FC<EditStudentProfileModalProps> = ({
       lastName: student.lastName,
       email: student.email,
       phone: student.phone || '',
-      group: student.group || '',
+      group_name: student.group_name || '',
       major: student.major || '',
       course: student.course || undefined,
     },
@@ -190,7 +190,7 @@ const EditStudentProfileModal: React.FC<EditStudentProfileModalProps> = ({
               {/* Группа */}
               <FormField
                 control={form.control}
-                name="group"
+                name="group_name"
                 render={({ field }) => (
                   <FormItem>
                     <FormLabel>{t('student.group', 'Группа')}</FormLabel>

--- a/client/src/components/students/StudentCard.tsx
+++ b/client/src/components/students/StudentCard.tsx
@@ -38,7 +38,7 @@ export interface Student {
   lastName: string;
   email: string;
   phone?: string;
-  group?: string;
+  group_name?: string;
   groupId?: number;
   major?: string;
   course?: number;
@@ -143,7 +143,7 @@ const StudentCard: React.FC<StudentCardProps> = ({ student, onClick }) => {
                   {student.firstName} {student.lastName}
                 </h3>
                 <p className="text-sm text-muted-foreground">
-                  {student.group && `${student.group} • `}
+                  {student.group_name && `${student.group_name} • `}
                   {student.major && `${student.major} • `}
                   {student.course && `${student.course} курс`}
                 </p>

--- a/client/src/components/users/EditUserProfileModal.tsx
+++ b/client/src/components/users/EditUserProfileModal.tsx
@@ -47,7 +47,7 @@ export interface UserProfile {
   organization?: string;
   title?: string;
   // Специфичные поля для студента
-  group?: string;
+  group_name?: string;
   major?: string;
   course?: number;
   // Специфичные поля для преподавателя
@@ -87,7 +87,7 @@ const EditUserProfileModal: React.FC<EditUserProfileModalProps> = ({
     organization: z.string().optional(),
     title: z.string().optional(),
     // Поля для студента
-    group: z.string().optional(),
+    group_name: z.string().optional(),
     major: z.string().optional(),
     course: z.coerce.number().int().positive().optional(),
     // Поля для преподавателя
@@ -111,7 +111,7 @@ const EditUserProfileModal: React.FC<EditUserProfileModalProps> = ({
       organization: user.organization || '',
       title: user.title || '',
       // Поля для студента
-      group: user.group || '',
+      group_name: user.group_name || '',
       major: user.major || '',
       course: user.course,
       // Поля для преподавателя
@@ -138,7 +138,7 @@ const EditUserProfileModal: React.FC<EditUserProfileModalProps> = ({
 
       // Дополнительные поля профиля
       if (data.phone) formData.phone = data.phone;
-      if (data.group) formData.group = data.group;
+      if (data.group_name) formData.group_name = data.group_name;
       if (data.major) formData.major = data.major;
       if (data.course) formData.course = data.course;
 
@@ -377,7 +377,7 @@ const EditUserProfileModal: React.FC<EditUserProfileModalProps> = ({
                   {/* Группа */}
                   <FormField
                     control={form.control}
-                    name="group"
+                    name="group_name"
                     render={({ field }) => (
                       <FormItem>
                         <FormLabel>{t('student.group', 'Группа')}</FormLabel>

--- a/client/src/components/users/StudentCard.tsx
+++ b/client/src/components/users/StudentCard.tsx
@@ -39,7 +39,7 @@ export interface UpcomingLesson {
 
 // Интерфейс для данных студента
 export interface Student extends UserData {
-  group?: string;
+  group_name?: string;
   groupId?: number;
   major?: string;
   course?: number;
@@ -183,9 +183,9 @@ const StudentCard: React.FC<StudentCardProps> = ({
                     <GraduationCap className="h-3.5 w-3.5" />
                     {t('roles.student', 'Студент')}
                   </Badge>
-                  {studentData.group && (
+                  {studentData.group_name && (
                     <Badge variant="outline" className="text-sm">
-                      {studentData.group}
+                      {studentData.group_name}
                     </Badge>
                   )}
                 </div>

--- a/client/src/hooks/useStudentDetail.ts
+++ b/client/src/hooks/useStudentDetail.ts
@@ -142,7 +142,7 @@ export function useStudentDetail(id: string | undefined) {
       email: userData.email,
       phone: userData.phone,
       groupId: userData.groupId,
-      group: 'ИС-101',
+      group_name: 'ИС-101',
       major: 'Информатика и ВТ',
       course: 3,
       lastLogin: userData.createdAt,

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -22,7 +22,7 @@ export const users = pgTable("users", {
   password: text("password").notNull(),
   email: text("email").notNull().unique(),
   phone: text("phone"),
-  group: text("group"),
+  group_name: text("group_name"),
   major: text("major"),
   course: integer("course"),
   role: roleEnum("role").notNull(),
@@ -269,7 +269,7 @@ export const insertUserSchema = createInsertSchema(users).omit({
   id: true,
   createdAt: true
 }).extend({
-  group: z.string().optional(),
+  group_name: z.string().optional(),
   major: z.string().optional(),
   course: z.number().int().optional(),
 });


### PR DESCRIPTION
## Summary
- add `group_name` column to user schema and update insert schema
- update user profile editing modal to handle `group_name`
- update student forms and card components for new field
- adjust student detail hook for renamed property

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_68638ec71ab08320a13a25f2b2c75a6f