### PR TITLE
Fix FormData upload

### DIFF
--- a/client/src/components/assignments/AssignmentDetails.tsx
+++ b/client/src/components/assignments/AssignmentDetails.tsx
@@ -16,7 +16,7 @@ interface AssignmentDetailsProps {
   submission?: Submission;
   creator?: User;
   isTeacher: boolean;
-  onSubmit: (formData: FormData) => Promise<any>;
+  onSubmit: (file: File) => Promise<any>;
   onGrade?: (submissionId: string, grade: number, feedback: string) => Promise<any>;
 }
 

--- a/client/src/components/files/FileUpload.tsx
+++ b/client/src/components/files/FileUpload.tsx
@@ -8,7 +8,7 @@ import { Alert, AlertDescription } from '@/components/ui/alert';
 import { useToast } from '@/hooks/use-toast';
 
 interface FileUploadProps {
-  onUpload: (formData: FormData) => Promise<any>;
+  onUpload: (file: File) => Promise<any>;
   fieldName?: string;
   acceptedFileTypes?: string;
   maxFileSizeMB?: number;
@@ -90,18 +90,14 @@ const FileUpload: React.FC<FileUploadProps> = ({
   
   const handleUpload = async () => {
     if (files.length === 0) return;
-    
+
     setUploading(true);
     setProgress(0);
     setError(null);
-    
+
     try {
-      const formData = new FormData();
-      
-      files.forEach((file) => {
-        formData.append(fieldName, file);
-      });
-      
+      const file = files[0];
+
       // Simulate progress
       const interval = setInterval(() => {
         setProgress(prev => {
@@ -113,8 +109,8 @@ const FileUpload: React.FC<FileUploadProps> = ({
           return newProgress;
         });
       }, 100);
-      
-      await onUpload(formData);
+
+      await onUpload(file);
       
       clearInterval(interval);
       setProgress(100);

--- a/client/src/components/schedule/ScheduleImport.tsx
+++ b/client/src/components/schedule/ScheduleImport.tsx
@@ -4,7 +4,6 @@ import FileUpload from '@/components/files/FileUpload';
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { queryClient } from '@/lib/queryClient';
-import { uploadFile } from '@/lib/api';
 import { useToast } from '@/hooks/use-toast';
 import { AlertCircle, CheckCircle, XCircle, ShieldAlert, Download } from 'lucide-react';
 import { useAuth } from '@/hooks/use-auth';
@@ -30,8 +29,16 @@ export default function ScheduleImport() {
 
   const userIsAdmin = user?.role === 'admin';
 
-  const handleFileUpload = async (formData: FormData) => {
-    const result = (await uploadFile('/api/schedule/import/csv', formData)) as ImportResponse;
+  const handleFileUpload = async (file: File) => {
+    const formData = new FormData();
+    formData.append('csvFile', file);
+
+    const response = await fetch('/api/schedule/import/csv', {
+      method: 'POST',
+      body: formData
+    });
+
+    const result = (await response.json()) as ImportResponse;
     setImportResult(result.result);
 
     toast({ title: 'Import Completed', description: result.message });

--- a/client/src/lib/queryClient.ts
+++ b/client/src/lib/queryClient.ts
@@ -47,6 +47,10 @@ export async function authFetch(
     ...(options.headers ?? {}),
   };
 
+  if (options.body instanceof FormData) {
+    delete (headers as Record<string, string>)['Content-Type'];
+  }
+
   if (token) {
     (headers as Record<string, string>)["Authorization"] = `Bearer ${token}`;
   }

--- a/client/src/pages/assignments/AssignmentDetail.tsx
+++ b/client/src/pages/assignments/AssignmentDetail.tsx
@@ -98,7 +98,9 @@ const AssignmentDetail = () => {
     },
   });
   
-  const handleSubmit = async (formData: FormData) => {
+  const handleSubmit = async (file: File) => {
+    const formData = new FormData();
+    formData.append('file', file);
     await submitAssignmentMutation.mutateAsync(formData);
   };
   


### PR DESCRIPTION
## Summary
- adjust `FileUpload` to pass a `File` instead of FormData
- handle FormData creation in `ScheduleImport`
- update assignment pages to create form data from selected file
- strip `Content-Type` header in `authFetch` when uploading files

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68640412dd70832082ee2143e82bc7bf