### PR TITLE
Add role-based schedule filtering and group import

### DIFF
--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -56,6 +56,8 @@ export const scheduleItems = pgTable("schedule_items", {
   endTime: time("end_time").notNull(),
   roomNumber: text("room_number"),
   teacherName: text("teacher_name"), // Имя преподавателя как строка, без связи с пользователями
+  // Название группы, поддерживает несколько групп через запятую
+  groupName: text("group_name"),
   importedFileId: uuid("imported_file_id"), // Связь с файлом импорта, если запись была импортирована
 });
 


### PR DESCRIPTION
## Summary
- include `groupName` column in schedule item schema
- filter schedule list per user role and group
- preserve group data when importing CSV schedule

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6866927dc7448320925350193ffff6ab