### PR TITLE
Fix AuthenticatedUser type to include group name

### DIFF
--- a/server/middleware/verifySupabaseJwt.ts
+++ b/server/middleware/verifySupabaseJwt.ts
@@ -46,6 +46,7 @@ export async function verifySupabaseJwt(req: Request, res: Response, next: NextF
       firstName: dbUser.firstName,
       lastName: dbUser.lastName,
       phone: dbUser.phone,
+      group_name: (dbUser as any).group_name,
       role: dbUser.role,
     };
 

--- a/server/types/auth.ts
+++ b/server/types/auth.ts
@@ -6,6 +6,8 @@ export interface AuthenticatedUser {
   firstName: string;
   lastName: string;
   phone?: string;
+  /** Optional group name from public.users for student filtering */
+  group_name?: string;
   role: UserRole;
 }
 

--- a/server/utils/userMapping.ts
+++ b/server/utils/userMapping.ts
@@ -22,6 +22,7 @@ export async function getDbUserBySupabaseUser(
       lastName: user.lastName,
       email: user.email,
       phone: (user as any).phone,
+      group_name: (user as any).group_name,
       role: user.role,
       createdAt: (user as any).createdAt,
       updatedAt: (user as any).updatedAt,


### PR DESCRIPTION
## Summary
- add optional `group_name` field to `AuthenticatedUser`
- expose group name when mapping Supabase user info
- include group name in middleware user object

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6866ad6648508320b6985d6bc2a30981