### PR TITLE
Improve schedule display with group info

### DIFF
--- a/client/src/components/schedule/ClassSchedule.tsx
+++ b/client/src/components/schedule/ClassSchedule.tsx
@@ -113,8 +113,15 @@ const ClassSchedule: React.FC<ClassScheduleProps> = ({ scheduleItems }) => {
                         </div>
                       </div>
                       <div className="text-right flex flex-col justify-center">
-                        <p className="text-sm font-medium text-neutral-700">
-                          {formatTime(item.startTime)} - {formatTime(item.endTime)}
+                        <p className="text-sm font-medium text-neutral-700 flex flex-wrap items-center justify-end">
+                          <span>
+                            {formatTime(item.startTime)} - {formatTime(item.endTime)}
+                          </span>
+                          {item.group_name && (
+                            <span className="text-xs text-neutral-500 ml-2">
+                              {item.group_name}
+                            </span>
+                          )}
                         </p>
                         <p className="text-xs text-neutral-500 mt-1">{getDayName(item.dayOfWeek)}</p>
                       </div>

--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -19,9 +19,10 @@ export function formatDate(
 
 export function formatTime(time: string): string {
   if (!time) return 'N/A';
-  // Предполагаем, что время уже в формате HH:MM
-  // Поэтому возвращаем его как есть
-  return time;
+  const parts = time.split(':');
+  if (parts.length < 2) return time;
+  const [hours, minutes] = parts;
+  return `${hours}:${minutes}`;
 }
 
 export function getRelativeTime(date: Date | string): string {

--- a/client/src/pages/schedule/Schedule.tsx
+++ b/client/src/pages/schedule/Schedule.tsx
@@ -142,9 +142,16 @@ export default function Schedule() {
                         {item.subject?.name || 'Неизвестный предмет'}
                       </TableCell>
                       <TableCell>
-                        <div className="flex items-center gap-1">
+                        <div className="flex flex-wrap items-center gap-1">
                           <Clock className="h-4 w-4 text-muted-foreground" />
-                          {formatTime(item.startTime)} - {formatTime(item.endTime)}
+                          <span>
+                            {formatTime(item.startTime)} - {formatTime(item.endTime)}
+                          </span>
+                          {item.group_name && (
+                            <span className="text-xs text-muted-foreground sm:ml-2">
+                              {item.group_name}
+                            </span>
+                          )}
                         </div>
                       </TableCell>
                       <TableCell className="hide-md">


### PR DESCRIPTION
## Summary
- format time helper to drop seconds
- show group name next to time in schedule table
- include group name in class schedule cards

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_68676c8a65a88320b2fe6dce1395f2ab