### PR TITLE
Fix dashboard status card grids

### DIFF
--- a/client/src/components/dashboards/AdminDashboard.tsx
+++ b/client/src/components/dashboards/AdminDashboard.tsx
@@ -135,7 +135,7 @@ const AdminDashboard = () => {
     <div className="space-y-6">
       {/* Удаляем тестовый элемент, так как теперь есть глобальный топбар */}
       {/* User and Task Statistics Cards */}
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
         <StatusCard
           title={t('users.roles.students')}
           value={userStats.studentCount.toString()}

--- a/client/src/components/dashboards/StudentDashboard.tsx
+++ b/client/src/components/dashboards/StudentDashboard.tsx
@@ -183,7 +183,7 @@ const StudentDashboard = () => {
       )}
       
       {/* Status Cards */}
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
         {/* Nearest Class */}
         <StatusCard
           title={t('dashboard.student.nextClass', 'Ближайшее занятие')}

--- a/client/src/components/dashboards/TeacherDashboard.tsx
+++ b/client/src/components/dashboards/TeacherDashboard.tsx
@@ -170,7 +170,7 @@ const TeacherDashboard = () => {
   return (
     <div className="space-y-6">
       {/* Status Cards */}
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
         <StatusCard
           title={t('dashboard.teacher.classGroups', 'Список групп и предметов')}
           value={subjects.length.toString()}


### PR DESCRIPTION
## Summary
- unify responsive breakpoints for status cards across dashboards
- ensure Student, Teacher and Admin dashboards use `sm` instead of `md`

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_686770c155dc83208f95cad8698f3c73