### PR TITLE
feat: add modal portal and focus trap

### DIFF
--- a/client/src/features/calendar/components/DayDetailsModal.tsx
+++ b/client/src/features/calendar/components/DayDetailsModal.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import ModalPortal from '@/features/modals/components/ModalPortal';
+import { useFocusTrap } from '@/features/modals/hooks/useFocusTrap';
+import portalStyles from '@/features/modals/styles/ModalPortal.module.css';
+import styles from '../styles/DayDetailsModal.module.css';
+
+interface DayDetailsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  children?: React.ReactNode;
+}
+
+const DayDetailsModal: React.FC<DayDetailsModalProps> = ({ isOpen, onClose, children }) => {
+  const focusTrapRef = useFocusTrap(isOpen);
+
+  return (
+    <ModalPortal isOpen={isOpen} onClose={onClose} className={portalStyles.portal}>
+      <div ref={focusTrapRef} className={styles.modal}>
+        {children}
+      </div>
+    </ModalPortal>
+  );
+};
+
+export default DayDetailsModal;

--- a/client/src/features/calendar/styles/DayDetailsModal.module.css
+++ b/client/src/features/calendar/styles/DayDetailsModal.module.css
@@ -1,0 +1,8 @@
+.modal {
+  background: var(--background, #fff);
+  border-radius: 8px;
+  padding: 1rem;
+  max-width: 90%;
+  max-height: 90%;
+  overflow-y: auto;
+}

--- a/client/src/features/modals/components/ModalPortal.tsx
+++ b/client/src/features/modals/components/ModalPortal.tsx
@@ -1,0 +1,62 @@
+import { createPortal } from 'react-dom';
+import { useEffect, useRef } from 'react';
+
+interface ModalPortalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  children: React.ReactNode;
+  className?: string;
+}
+
+const ModalPortal: React.FC<ModalPortalProps> = ({
+  isOpen,
+  onClose,
+  children,
+  className
+}) => {
+  const portalRoot = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    // Создать или найти portal root
+    let root = document.getElementById('modal-root');
+    if (!root) {
+      root = document.createElement('div');
+      root.id = 'modal-root';
+      document.body.appendChild(root);
+    }
+    portalRoot.current = root;
+  }, []);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    // Background scroll lock
+    const originalOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+
+    // Escape key handling
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    document.addEventListener('keydown', handleEscape);
+
+    return () => {
+      document.body.style.overflow = originalOverflow;
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [isOpen, onClose]);
+
+  if (!isOpen || !portalRoot.current) return null;
+
+  return createPortal(
+    <div className={className}>
+      {children}
+    </div>,
+    portalRoot.current
+  );
+};
+
+export default ModalPortal;

--- a/client/src/features/modals/hooks/useFocusTrap.ts
+++ b/client/src/features/modals/hooks/useFocusTrap.ts
@@ -1,0 +1,54 @@
+import { useEffect, useRef } from 'react';
+
+export const useFocusTrap = (isOpen: boolean) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    // Сохранить текущий focus
+    previousFocusRef.current = document.activeElement as HTMLElement;
+
+    // Focus на modal
+    const focusableElements = containerRef.current?.querySelectorAll(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+    );
+
+    if (focusableElements?.length) {
+      (focusableElements[0] as HTMLElement).focus();
+    }
+
+    // Trap focus внутри modal
+    const handleTab = (e: KeyboardEvent) => {
+      if (e.key !== 'Tab' || !focusableElements?.length) return;
+
+      const firstElement = focusableElements[0] as HTMLElement;
+      const lastElement = focusableElements[focusableElements.length - 1] as HTMLElement;
+
+      if (e.shiftKey) {
+        if (document.activeElement === firstElement) {
+          e.preventDefault();
+          lastElement.focus();
+        }
+      } else {
+        if (document.activeElement === lastElement) {
+          e.preventDefault();
+          firstElement.focus();
+        }
+      }
+    };
+
+    document.addEventListener('keydown', handleTab);
+
+    return () => {
+      // Восстановить focus
+      if (previousFocusRef.current) {
+        previousFocusRef.current.focus();
+      }
+      document.removeEventListener('keydown', handleTab);
+    };
+  }, [isOpen]);
+
+  return containerRef;
+};

--- a/client/src/features/modals/styles/ModalPortal.module.css
+++ b/client/src/features/modals/styles/ModalPortal.module.css
@@ -1,0 +1,33 @@
+.portal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: var(--z-modal, 1000);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(4px);
+  
+  /* Animation preparation */
+  opacity: 0;
+  animation: fadeIn 200ms ease-out forwards;
+}
+
+@keyframes fadeIn {
+  to {
+    opacity: 1;
+  }
+}
+
+.portal.closing {
+  animation: fadeOut 150ms ease-in forwards;
+}
+
+@keyframes fadeOut {
+  to {
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Summary
- add base ModalPortal component with escape handling and scroll lock
- add focus trap hook for modals
- use ModalPortal in DayDetailsModal

## Testing
- `npm run check` *(fails: No overload matches this call in server/storage.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689d8a6eb8f083209caf23a6681a1796